### PR TITLE
Return amounts for each tax

### DIFF
--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -257,9 +257,9 @@ def inner_loop(outer_loop_vars, p, client):
         etr_params_3D = np.tile(np.reshape(
             p.etr_params[-1, :, :], (p.S, 1, p.etr_params.shape[2])),
                                 (1, p.J, 1))
-        new_T_H, _, _, _, _, = aggr.revenue(new_r, new_w, b_s, nssmat, new_BQ, new_Y,
-                               L, K, factor, theta,
-                               etr_params_3D, p, 'SS')
+        new_T_H, _, _, _, _, _ = aggr.revenue(
+            new_r, new_w, b_s, nssmat, new_BQ, new_Y, L, K, factor,
+            theta, etr_params_3D, p, 'SS')
     elif p.baseline_spending:
         new_T_H = T_H
     else:

--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -257,7 +257,7 @@ def inner_loop(outer_loop_vars, p, client):
         etr_params_3D = np.tile(np.reshape(
             p.etr_params[-1, :, :], (p.S, 1, p.etr_params.shape[2])),
                                 (1, p.J, 1))
-        new_T_H = aggr.revenue(new_r, new_w, b_s, nssmat, new_BQ, new_Y,
+        new_T_H, _, _, _, _, = aggr.revenue(new_r, new_w, b_s, nssmat, new_BQ, new_Y,
                                L, K, factor, theta,
                                etr_params_3D, p, 'SS')
     elif p.baseline_spending:
@@ -437,9 +437,9 @@ def SS_solver(bmat, nmat, r, T_H, factor, Y, p, client,
 
     etr_params_3D = np.tile(np.reshape(
         p.etr_params[-1, :, :], (p.S, 1, p.etr_params.shape[2])), (1, p.J, 1))
-    total_revenue_ss = aggr.revenue(
-        rss, wss, bssmat_s, nssmat, BQss, Yss, Lss, Kss, factor, theta,
-        etr_params_3D, p, 'SS')
+    total_revenue_ss, T_Iss, T_Pss, T_BQss, T_Wss, business_revenue =\
+        aggr.revenue(rss, wss, bssmat_s, nssmat, BQss, Yss, Lss, Kss,
+                     factor, theta, etr_params_3D, p, 'SS')
     r_gov_ss = rss
     debt_service_ss = r_gov_ss * p.debt_ratio_ss * Yss
     new_borrowing = p.debt_ratio_ss * Yss * ((1 + p.g_n_ss) *
@@ -475,9 +475,6 @@ def SS_solver(bmat, nmat, r, T_H, factor, Y, p, client,
     cssmat = household.get_cons(rss, wss, bssmat_s, bssmat_splus1,
                                 nssmat, BQss.reshape(1, p.J), taxss,
                                 p.e, None, p)
-
-    business_revenue = tax.get_biz_tax(wss, Yss, Lss, Kss, p, 'SS')
-    IITpayroll_revenue = total_revenue_ss - business_revenue
 
     Css = aggr.get_C(cssmat, p, 'SS')
 
@@ -543,7 +540,8 @@ def SS_solver(bmat, nmat, r, T_H, factor, Y, p, client,
               'T_Hss': T_Hss, 'Gss': Gss,
               'total_revenue_ss': total_revenue_ss,
               'business_revenue': business_revenue,
-              'IITpayroll_revenue': IITpayroll_revenue,
+              'IITpayroll_revenue': T_Iss,
+              'T_Pss': T_Pss, 'T_BQss': T_BQss, 'T_Wss': T_Wss,
               'euler_savings': euler_savings,
               'euler_labor_leisure': euler_labor_leisure,
               'etr_ss': etr_ss, 'mtrx_ss': mtrx_ss, 'mtry_ss': mtry_ss}

--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -544,6 +544,7 @@ def SS_solver(bmat, nmat, r, T_H, factor, Y, p, client,
               'T_Pss': T_Pss, 'T_BQss': T_BQss, 'T_Wss': T_Wss,
               'euler_savings': euler_savings,
               'euler_labor_leisure': euler_labor_leisure,
+              'resource_constraint_error': resource_constraint, 
               'etr_ss': etr_ss, 'mtrx_ss': mtrx_ss, 'mtry_ss': mtry_ss}
 
     return output

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -548,14 +548,13 @@ def run_TPI(p, client=None):
                 if not p.baseline_spending:
                     Y = T_H / p.alpha_T  # maybe unecessary
 
-                (total_revenue, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
-                 business_revenue) = np.array(list(
-                    aggr.revenue(r[:p.T], w[:p.T], bmat_s,
-                                 n_mat[:p.T, :, :], BQ_3D[:p.T, :, :],
-                                 Y[:p.T], L[:p.T], K[:p.T], factor,
-                                 theta, etr_params_4D, p, 'TPI')) +
-                                   [total_revenue_ss] * p.S)
-
+                (total_rev, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
+                 business_revenue) = aggr.revenue(
+                     r[:p.T], w[:p.T], bmat_s, n_mat[:p.T, :, :],
+                     BQ_3D[:p.T, :, :], Y[:p.T], L[:p.T], K[:p.T],
+                     factor, theta, etr_params_4D, p, 'TPI')
+                total_revenue = np.array(list(total_rev) +
+                                         [total_revenue_ss] * p.S)
                 # set intial debt value
                 if p.baseline:
                     D_0 = p.initial_debt_ratio * Y[0]
@@ -587,12 +586,14 @@ def run_TPI(p, client=None):
         BQnew = aggr.get_BQ(rnew[:p.T], b_mat_shift, None, p, 'TPI', False)
         BQnew_3D = np.tile(BQnew.reshape(BQnew.shape[0], 1, BQnew.shape[1]),
                            (1, p.S, 1))
-        (total_revenue, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
-         business_revenue) = np.array(list(
-            aggr.revenue(rnew[:p.T], wnew[:p.T], bmat_s,
-                         n_mat[:p.T, :, :], BQnew_3D[:p.T, :, :], Ynew[:p.T],
-                         L[:p.T], K[:p.T], factor, theta, etr_params_4D,
-                         p, 'TPI')) + [total_revenue_ss] * p.S)
+
+        (total_rev, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
+         business_revenue) = aggr.revenue(
+             rnew[:p.T], wnew[:p.T], bmat_s, n_mat[:p.T, :, :],
+             BQnew_3D[:p.T, :, :], Ynew[:p.T], L[:p.T], K[:p.T],
+             factor, theta, etr_params_4D, p, 'TPI')
+        total_revenue = np.array(list(total_rev) +
+                                 [total_revenue_ss] * p.S)
 
         if p.budget_balance:
             T_H_new = total_revenue

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -745,6 +745,7 @@ def run_TPI(p, client=None):
               'c_path': c_path,
               'tax_path': tax_path, 'eul_savings': eul_savings,
               'eul_laborleisure': eul_laborleisure,
+              'resource_constraint_error': rc_error,
               'etr_path': etr_path, 'mtrx_path': mtrx_path,
               'mtry_path': mtry_path}
 

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -548,7 +548,8 @@ def run_TPI(p, client=None):
                 if not p.baseline_spending:
                     Y = T_H / p.alpha_T  # maybe unecessary
 
-                total_revenue = np.array(list(
+                (total_revenue, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
+                 business_revenue) = np.array(list(
                     aggr.revenue(r[:p.T], w[:p.T], bmat_s,
                                  n_mat[:p.T, :, :], BQ_3D[:p.T, :, :],
                                  Y[:p.T], L[:p.T], K[:p.T], factor,
@@ -586,7 +587,8 @@ def run_TPI(p, client=None):
         BQnew = aggr.get_BQ(rnew[:p.T], b_mat_shift, None, p, 'TPI', False)
         BQnew_3D = np.tile(BQnew.reshape(BQnew.shape[0], 1, BQnew.shape[1]),
                            (1, p.S, 1))
-        total_revenue = np.array(list(
+        (total_revenue, T_Ipath, T_Ppath, T_BQpath, T_Wpath,
+         business_revenue) = np.array(list(
             aggr.revenue(rnew[:p.T], wnew[:p.T], bmat_s,
                          n_mat[:p.T, :, :], BQnew_3D[:p.T, :, :], Ynew[:p.T],
                          L[:p.T], K[:p.T], factor, theta, etr_params_4D,
@@ -711,10 +713,6 @@ def run_TPI(p, client=None):
     I_total = ((1 + p.g_n[:p.T]) * np.exp(p.g_y) * K[1:p.T + 1] -
                (1.0 - p.delta) * K[:p.T])
 
-    # Compute business and invidiual income tax revenue
-    business_revenue = tax.get_biz_tax(w[:p.T], Y[:p.T], L[:p.T],
-                                       K[:p.T], p, 'TPI')
-    IITpayroll_revenue = total_revenue[:p.T] - business_revenue[:p.T]
     rce_max = np.amax(np.abs(rc_error))
     print('Max absolute value resource constraint error:', rce_max)
 
@@ -738,7 +736,8 @@ def run_TPI(p, client=None):
     output = {'Y': Y[:p.T], 'B': B, 'K': K, 'L': L, 'C': C, 'I': I,
               'I_total': I_total, 'BQ': BQ, 'total_revenue': total_revenue,
               'business_revenue': business_revenue,
-              'IITpayroll_revenue': IITpayroll_revenue, 'T_H': T_H,
+              'IITpayroll_revenue': T_Ipath, 'T_H': T_H,
+              'T_P': T_Ppath, 'T_BQ': T_BQpath, 'T_W': T_Wpath,
               'G': G, 'D': D, 'r': r, 'w': w,
               'bmat_splus1': bmat_splus1,
               'bmat_s': bmat_s[:p.T, :, :], 'n_mat': n_mat[:p.T, :, :],
@@ -747,7 +746,6 @@ def run_TPI(p, client=None):
               'eul_laborleisure': eul_laborleisure,
               'etr_path': etr_path, 'mtrx_path': mtrx_path,
               'mtry_path': mtry_path}
-
 
     tpi_dir = os.path.join(p.output_base, 'TPI')
     utils.mkdirs(tpi_dir)

--- a/ogusa/aggregates.py
+++ b/ogusa/aggregates.py
@@ -320,4 +320,4 @@ def revenue(r, w, b, n, BQ, Y, L, K, factor, theta, etr_params, p, method):
                    * (T_I + T_P + T_BQ + T_W)).sum(1).sum(1) +
                    business_revenue)
 
-    return REVENUE
+    return REVENUE, agg_T_I, agg_T_P, agg_T_BQ, agg_T_W, business_revenue

--- a/ogusa/aggregates.py
+++ b/ogusa/aggregates.py
@@ -320,4 +320,4 @@ def revenue(r, w, b, n, BQ, Y, L, K, factor, theta, etr_params, p, method):
                    * (T_I + T_P + T_BQ + T_W)).sum(1).sum(1) +
                    business_revenue)
 
-    return REVENUE, agg_T_I, agg_T_P, agg_T_BQ, agg_T_W, business_revenue
+    return REVENUE, T_I, T_P, T_BQ, T_W, business_revenue

--- a/ogusa/tests/test_SS.py
+++ b/ogusa/tests/test_SS.py
@@ -238,6 +238,9 @@ def test_SS_solver():
     # delete values key-value pairs that are not in both dicts
     del expected_dict['bssmat'], expected_dict['chi_n'], expected_dict['chi_b']
     del test_dict['etr_ss'], test_dict['mtrx_ss'], test_dict['mtry_ss']
+    test_dict['IITpayroll_revenue'] = (test_dict['total_revenue_ss'] -
+                                       test_dict['business_revenue'])
+    del test_dict['T_Pss'], test_dict['T_BQss'], test_dict['T_Wss']
     test_dict['revenue_ss'] = test_dict.pop('total_revenue_ss')
 
     for k, v in expected_dict.items():
@@ -392,6 +395,9 @@ def test_run_SS(input_path, expected_path):
     # delete values key-value pairs that are not in both dicts
     del expected_dict['bssmat'], expected_dict['chi_n'], expected_dict['chi_b']
     del test_dict['etr_ss'], test_dict['mtrx_ss'], test_dict['mtry_ss']
+    test_dict['IITpayroll_revenue'] = (test_dict['total_revenue_ss'] -
+                                       test_dict['business_revenue'])
+    del test_dict['T_Pss'], test_dict['T_BQss'], test_dict['T_Wss']
     test_dict['revenue_ss'] = test_dict.pop('total_revenue_ss')
 
     for k, v in expected_dict.items():

--- a/ogusa/tests/test_SS.py
+++ b/ogusa/tests/test_SS.py
@@ -398,6 +398,7 @@ def test_run_SS(input_path, expected_path):
     test_dict['IITpayroll_revenue'] = (test_dict['total_revenue_ss'] -
                                        test_dict['business_revenue'])
     del test_dict['T_Pss'], test_dict['T_BQss'], test_dict['T_Wss']
+    del test_dict['resource_constraint_error']
     test_dict['revenue_ss'] = test_dict.pop('total_revenue_ss')
 
     for k, v in expected_dict.items():

--- a/ogusa/tests/test_TPI.py
+++ b/ogusa/tests/test_TPI.py
@@ -231,6 +231,9 @@ def test_run_TPI():
     del test_dict['bmat_s']
     test_dict['b_mat'] = test_dict.pop('bmat_splus1')
     test_dict['REVENUE'] = test_dict.pop('total_revenue')
+    test_dict['IITpayroll_revenue'] = (test_dict['REVENUE'][:160] -
+                                       test_dict['business_revenue'])
+    del test_dict['T_P'], test_dict['T_BQ'], test_dict['T_W']
 
     for k, v in expected_dict.items():
         try:

--- a/ogusa/tests/test_TPI.py
+++ b/ogusa/tests/test_TPI.py
@@ -234,6 +234,7 @@ def test_run_TPI():
     test_dict['IITpayroll_revenue'] = (test_dict['REVENUE'][:160] -
                                        test_dict['business_revenue'])
     del test_dict['T_P'], test_dict['T_BQ'], test_dict['T_W']
+    del test_dict['resource_constraint_error']
 
     for k, v in expected_dict.items():
         try:

--- a/ogusa/tests/test_aggregates.py
+++ b/ogusa/tests/test_aggregates.py
@@ -4,309 +4,254 @@ from ogusa import aggregates as aggr
 from ogusa.parameters import Specifications
 
 
-def test_get_L():
+p = Specifications()
+new_param_values = {
+    'T': 160,
+    'S': 40,
+    'J': 2,
+    'lambdas': [0.6, 0.4]
+}
+# update parameters instance with new values for test
+p.update_specifications(new_param_values)
+n = np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
+L_loop = np.ones(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
+for t in range(p.T):
+    for i in range(p.S):
+        for k in range(p.J):
+            L_loop[t, i, k] *= (p.omega[t, i] * p.lambdas[k] *
+                                n[t, i, k] * p.e[i, k])
+expected1 = L_loop[-1, :, :].sum()
+expected2 = L_loop.sum(1).sum(1)
+test_data = [(n[-1, :, :], p, 'SS', expected1), (n, p, 'TPI', expected2)]
+
+
+@pytest.mark.parametrize('n,p,method,expected', test_data, ids=['SS', 'TPI'])
+def test_get_L(n, p, method, expected):
     """
-        Simulate data similar to observed and carry out get_L
-        in simplest way possible.
+        Test aggregate labor function.
     """
-    p = Specifications()
-    new_param_values = {
-        'T': 160,
-        'S': 40,
-        'J': 2,
-        'lambdas': [0.6, 0.4]
-    }
-    # update parameters instance with new values for test
-    p.update_specifications(new_param_values, raise_errors=False)
-
-    # check that distributional parameters sum to one
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega_SS.sum(), 1.0)
-
-    n = np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-
-    # test matrix multiplication in 3 dimensions works as expected
-    L_loop = np.ones(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-    for t in range(p.T):
-        for i in range(p.S):
-            for k in range(p.J):
-                L_loop[t, i, k] *= (p.omega[t, i] * p.lambdas[k] *
-                                    n[t, i, k] * p.e[i, k])
-
-    L_matrix = p.e * np.transpose(p.omega_SS * p.lambdas) * n[-1, :, :]
-    assert (np.allclose(L_loop[-1, :, :], L_matrix))
-
-    # test SS
-    method = 'SS'
-    L = aggr.get_L(n[-1, :, :], p, method)
-    assert (np.allclose(L, L_loop[-1, :, :].sum()))
-
-    # test TPI
-    method = 'TPI'
     L = aggr.get_L(n, p, method)
-    assert (np.allclose(L, L_loop.sum(1).sum(1)))
+    assert (np.allclose(L, expected))
 
 
-def test_get_I():
+p = Specifications()
+new_param_values = {
+    'T': 160,
+    'S': 40,
+    'J': 2,
+    'lambdas': [0.6, 0.4],
+}
+# update parameters instance with new values for test
+p.update_specifications(new_param_values)
+b_splus1 = 10 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
+K_p1 = 0.9 + np.random.rand(p.T)
+K = 0.9 + np.random.rand(p.T)
+omega_extended = np.append(p.omega_SS[1:], [0.0])
+imm_extended = np.append(p.imm_rates[-1, 1:], [0.0])
+part2 = (((b_splus1[-1, :, :] *
+           np.transpose((omega_extended * imm_extended) *
+           p.lambdas)).sum()) / (1 + p.g_n_ss))
+aggI_SS = ((1 + p.g_n_ss) * np.exp(p.g_y) * (K_p1[-1] - part2) -
+           (1.0 - p.delta) * K[-1])
+omega_shift = np.append(p.omega[:p.T, 1:], np.zeros((p.T, 1)),
+                        axis=1)
+imm_shift = np.append(p.imm_rates[:p.T, 1:], np.zeros((p.T, 1)),
+                      axis=1)
+part2 = ((((b_splus1 * np.squeeze(p.lambdas)) *
+          np.tile(np.reshape(imm_shift * omega_shift,
+                             (p.T, p.S, 1)),
+                  (1, 1, p.J))).sum(1).sum(1)) /
+         (1 + np.squeeze(np.hstack((p.g_n[1:p.T], p.g_n_ss)))))
+aggI_TPI = ((1 + np.squeeze(np.hstack((p.g_n[1:p.T], p.g_n_ss))))
+            * np.exp(p.g_y) * (K_p1 - part2) - (1.0 - p.delta) * K)
+test_data = [(b_splus1[-1, :, :], K_p1[-1], K[-1], p, 'SS', aggI_SS),
+             (b_splus1, K_p1, K, p, 'TPI', aggI_TPI)]
+
+
+@pytest.mark.parametrize('b_splus1,K_p1,K,p,method,expected', test_data,
+                         ids=['SS', 'TPI'])
+def test_get_I(b_splus1, K_p1, K, p, method, expected):
     """
-        Simulate data similar to observed and carry out get_I
-        in simplest way possible.
+        Text aggregate investment function.
     """
-    p = Specifications()
-    new_param_values = {
-        'T': 160,
-        'S': 40,
-        'J': 2,
-        'lambdas': [0.6, 0.4],
-    }
-    # update parameters instance with new values for test
-    p.update_specifications(new_param_values, raise_errors=False)
-
-    # assign some values to variables
-    b_splus1 = 10 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-    K_p1 = 0.9 + np.random.rand(p.T)
-    K = 0.9 + np.random.rand(p.T)
-
-    # check sum of distributional parameters
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega[:p.T, :].sum(), p.T)
-
-    res_loop = np.ones(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-    for t in range(p.T):
-        for i in range(p.S):
-            for k in range(p.J):
-                res_loop[t, i, k] *= (p.omega[t, i] * p.imm_rates[t, i]
-                                      * p.lambdas[k] * b_splus1[t, i, k])
-
-    res_matrix = ((b_splus1 * np.squeeze(p.lambdas)) *
-                  np.tile(np.reshape((p.imm_rates[:p.T, :] *
-                                      p.omega[:p.T, :]), (p.T, p.S, 1)),
-                          (1, 1, p.J)))
-    # check that matrix operation and loop return same values
-    assert (np.allclose(res_loop, res_matrix))
-
-    # test SS
-    omega_extended = np.append(p.omega_SS[1:], [0.0])
-    imm_extended = np.append(p.imm_rates[-1, 1:], [0.0])
-    part2 = (((b_splus1[-1, :, :] *
-               np.transpose((omega_extended * imm_extended) *
-               p.lambdas)).sum()) / (1 + p.g_n_ss))
-    aggI_SS_test = ((1 + p.g_n_ss) * np.exp(p.g_y) *
-                    (K_p1[-1] - part2) -
-                    (1.0 - p.delta) * K[-1])
-    aggI_SS = aggr.get_I(b_splus1[-1, :, :], K_p1[-1], K[-1], p, 'SS')
-
-    assert (np.allclose(aggI_SS, aggI_SS_test))
-
-    omega_shift = np.append(p.omega[:p.T, 1:], np.zeros((p.T, 1)),
-                            axis=1)
-    imm_shift = np.append(p.imm_rates[:p.T, 1:], np.zeros((p.T, 1)),
-                          axis=1)
-    part2 = ((((b_splus1 * np.squeeze(p.lambdas)) *
-              np.tile(np.reshape(imm_shift * omega_shift,
-                                 (p.T, p.S, 1)),
-                      (1, 1, p.J))).sum(1).sum(1)) /
-             (1 + np.squeeze(np.hstack((p.g_n[1:p.T], p.g_n_ss)))))
-    aggI_TPI_test = ((1 + np.squeeze(np.hstack((p.g_n[1:p.T], p.g_n_ss))))
-                     * np.exp(p.g_y) * (K_p1 - part2) - (1.0 - p.delta)
-                     * K)
-    aggI_TPI = aggr.get_I(b_splus1, K_p1, K, p, 'TPI')
-    assert (np.allclose(aggI_TPI, aggI_TPI_test))
+    aggI = aggr.get_I(b_splus1, K_p1, K, p, method)
+    assert (np.allclose(aggI, expected))
 
 
-def test_get_K():
+p = Specifications()
+new_param_values = {
+    'T': 160,
+    'S': 40,
+    'J': 2,
+    'lambdas': [0.6, 0.4],
+}
+# update parameters instance with new values for test
+p.update_specifications(new_param_values)
+b = -0.1 + (7 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
+omega_extended = np.append(p.omega[:p.T, 1:], np.zeros((p.T, 1)),
+                           axis=1)
+imm_extended = np.append(p.imm_rates[:p.T, 1:], np.zeros((p.T, 1)),
+                         axis=1)
+K_test = ((b * np.squeeze(p.lambdas) *
+           np.tile(np.reshape(p.omega[:p.T, :], (p.T, p.S, 1)),
+                   (1, 1, p.J))) +
+          (b * np.squeeze(p.lambdas) *
+           np.tile(np.reshape(omega_extended *
+                              imm_extended, (p.T, p.S, 1)),
+                   (1, 1, p.J))))
+expected1 = K_test[-1, :, :].sum() / (1.0 + p.g_n_ss)
+expected2 = K_test.sum(1).sum(1) / (1.0 + np.hstack((p.g_n[1:p.T], p.g_n_ss)))
+test_data = [(b[-1, :, :], p, 'SS', expected1),
+             (b, p, 'TPI', expected2)]
+
+
+@pytest.mark.parametrize('b,p,method,expected', test_data,
+                         ids=['SS', 'TPI'])
+def test_get_K(b, p, method, expected):
     """
-    Simulate data similar to observed
+    Test aggregate capital function.
     """
-    p = Specifications()
-    new_param_values = {
-        'T': 160,
-        'S': 40,
-        'J': 2,
-        'lambdas': [0.6, 0.4],
-    }
-    # update parameters instance with new values for test
-    p.update_specifications(new_param_values, raise_errors=False)
+    K = aggr.get_K(b, p, method, False)
+    assert np.allclose(K, expected)
 
-    b = -0.1 + (7 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
 
-    # check that distributional parameters sum to one
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega[:p.T, :].sum(), p.T)
+p = Specifications()
+new_param_values = {
+    'T': 160,
+    'S': 40,
+    'J': 2,
+    'lambdas': [0.6, 0.4],
+}
+# update parameters instance with new values for test
+p.update_specifications(new_param_values)
+# set values for some variables
+r = 0.5 + 0.5 * np.random.rand(p.T)
+b_splus1 = 0.06 + 7 * np.random.rand(p.T, p.S, p.J)
+pop = np.append(p.omega_S_preTP.reshape(1, p.S),
+                p.omega[:p.T - 1, :], axis=0)
+BQ_presum = ((b_splus1 * np.squeeze(p.lambdas)) *
+             np.tile(np.reshape(p.rho * pop, (p.T, p.S, 1)),
+                     (1, 1, p.J)))
+growth_adj = (1.0 + r) / (1.0 + p.g_n[:p.T])
 
-    omega_extended = np.append(p.omega[:p.T, 1:], np.zeros((p.T, 1)),
-                               axis=1)
-    imm_extended = np.append(p.imm_rates[:p.T, 1:], np.zeros((p.T, 1)),
-                             axis=1)
+expected1 = BQ_presum[-1, :, :].sum(0) * growth_adj[-1]
+expected2 = BQ_presum[-1, :, 1].sum(0) * growth_adj[-1]
+expected3 = (BQ_presum.sum(1) *
+             np.tile(np.reshape(growth_adj, (p.T, 1)), (1, p.J)))
+expected4 = BQ_presum[:, :, 1].sum(1) * growth_adj
+test_data = [(r[-1], b_splus1[-1, :, :], None, p, 'SS', expected1),
+             (r[-1], b_splus1[-1, :, 1], 1, p, 'SS', expected2),
+             (r, b_splus1, None, p, 'TPI', expected3),
+             (r, b_splus1[:, :, 1], 1, p, 'TPI', expected4)]
 
-    K_test = ((b * np.squeeze(p.lambdas) *
+
+@pytest.mark.parametrize('r,b_splus1,j,p,method,expected', test_data,
+                         ids=['SS, all j', 'SS, one j', 'TPI, all j',
+                              'TPI, one j'])
+def test_get_BQ(r, b_splus1, j, p, method, expected):
+    """
+    Test of aggregate bequest function.
+    """
+    BQ = aggr.get_BQ(r, b_splus1, j, p, method, False)
+    assert np.allclose(BQ, expected)
+
+
+p = Specifications()
+new_param_values = {
+    'T': 160,
+    'S': 40,
+    'J': 2,
+    'lambdas': [0.6, 0.4],
+}
+# update parameters instance with new values for test
+p.update_specifications(new_param_values)
+# make up some consumption values for testing
+c = 0.1 + 0.5 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
+aggC_presum = ((c * np.squeeze(p.lambdas)) *
                np.tile(np.reshape(p.omega[:p.T, :], (p.T, p.S, 1)),
-                       (1, 1, p.J))) +
-              (b * np.squeeze(p.lambdas) *
-               np.tile(np.reshape(omega_extended *
-                                  imm_extended, (p.T, p.S, 1)),
-                       (1, 1, p.J))))
-    K = aggr.get_K(b[-1, :, :], p, "SS", False)
-
-    assert np.allclose(K_test[-1, :, :].sum() / (1.0 + p.g_n_ss), K)
-
-    K = aggr.get_K(b, p, "TPI", False)
-    assert np.allclose(K_test.sum(1).sum(1) /
-                       (1.0 + np.hstack((p.g_n[1:p.T], p.g_n_ss))), K)
+                       (1, 1, p.J)))
+expected1 = aggC_presum[-1, :, :].sum()
+expected2 = aggC_presum.sum(1).sum(1)
+test_data = [(c[-1, :, :], p, 'SS', expected1),
+             (c, p, 'TPI', expected2)]
 
 
-def test_get_BQ():
+@pytest.mark.parametrize('c,p,method,expected', test_data,
+                         ids=['SS', 'TPI'])
+def test_get_C(c, p, method, expected):
     """
-    Simulate data similar to observed
+    Test aggregate consumption function.
     """
-    p = Specifications()
-    new_param_values = {
-        'T': 160,
-        'S': 40,
-        'J': 2,
-        'lambdas': [0.6, 0.4],
-    }
-    # update parameters instance with new values for test
-    p.update_specifications(new_param_values, raise_errors=False)
-
-    # set values for some variables
-    r = 0.5 + 0.5 * np.random.rand(p.T)
-    b_splus1 = 0.06 + 7 * np.random.rand(p.T, p.S, p.J)
-
-    # check that distributional parameters sum to one
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega[:p.T, :].sum(), p.T)
-
-    pop = np.append(p.omega_S_preTP.reshape(1, p.S),
-                    p.omega[:p.T - 1, :], axis=0)
-    BQ_presum = ((b_splus1 * np.squeeze(p.lambdas)) *
-                 np.tile(np.reshape(p.rho * pop, (p.T, p.S, 1)),
-                         (1, 1, p.J)))
-    growth_adj = (1.0 + r) / (1.0 + p.g_n[:p.T])
-
-    # test SS
-    BQ = aggr.get_BQ(r[-1], b_splus1[-1, :, :], None, p, "SS", False)
-    assert np.allclose(BQ_presum[-1, :, :].sum(0) * growth_adj[-1], BQ)
-
-    # test SS for specific j
-    BQ = aggr.get_BQ(r[-1], b_splus1[-1, :, 1], 1, p, "SS", False)
-    assert np.allclose(BQ_presum[-1, :, 1].sum(0) * growth_adj[-1], BQ)
-
-    # test TPI
-    BQ = aggr.get_BQ(r, b_splus1, None, p, "TPI", False)
-    assert np.allclose(BQ_presum.sum(1) *
-                       np.tile(np.reshape(growth_adj, (p.T, 1)),
-                               (1, p.J)), BQ)
-
-    # test TPI for specific j
-    BQ = aggr.get_BQ(r, b_splus1[:, :, 1], 1, p, "TPI", False)
-    assert np.allclose(BQ_presum[:, :, 1].sum(1) * growth_adj, BQ)
+    C = aggr.get_C(c, p, method)
+    assert np.allclose(C, expected)
 
 
-def test_get_C():
+p = Specifications()
+dim4 = 12
+new_param_values = {
+    'T': 30,
+    'S': 20,
+    'J': 2,
+    'lambdas': [0.6, 0.4],
+    'tau_bq': [0.17],
+    'tau_payroll': [0.5],
+    'h_wealth': [0.1],
+    'p_wealth': [0.2],
+    'm_wealth': [1.0],
+    'tau_b': [0.2],
+    'delta_tau_annual': [float(1 - ((1 - 0.0975) **
+                                    (20 / (p.ending_age -
+                                           p.starting_age))))]
+}
+p.update_specifications(new_param_values)
+# make up some consumption values for testing
+# Assign values to variables for tests
+random_state = np.random.RandomState(10)
+r = 0.067 + (0.086 - 0.067) * random_state.rand(p.T)
+w = 0.866 + (0.927 - 0.866) * random_state.rand(p.T)
+b = 6.94 * random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
+n = (0.191 + (0.503 - 0.191) *
+     random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
+BQ = (0.032 + (0.055 - 0.032) *
+      random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
+Y = 0.561 + (0.602 - 0.561) * random_state.rand(p.T).reshape(p.T)
+L = 0.416 + (0.423 - 0.416) * random_state.rand(p.T).reshape(p.T)
+K = 0.957 + (1.163 - 0.957) * random_state.rand(p.T).reshape(p.T)
+factor = 140000.0
+# update parameters instance with new values for test
+p.e = (0.263 + (2.024 - 0.263) *
+       random_state.rand(p.S * p.J).reshape(p.S, p.J))
+p.omega = 0.039 * random_state.rand(p.T * p.S * 1).reshape(p.T, p.S)
+p.omega = p.omega/p.omega.sum(axis=1).reshape(p.T, 1)
+p.omega_SS = p.omega[-1, :]
+etr_params = (0.22 *
+              random_state.rand(p.T * p.S * dim4).reshape(p.T, p.S,
+                                                          dim4))
+etr_params = np.tile(np.reshape(etr_params, (p.T, p.S, 1, dim4)),
+                     (1, 1, p.J, 1))
+theta = 0.101 + (0.156 - 0.101) * random_state.rand(p.J)
+expected1 = 0.5562489534339288
+expected2 = [0.52178543, 0.49977116, 0.52015768, 0.52693363, 0.59695398,
+             0.61360011, 0.54679056, 0.54096669, 0.56301133, 0.5729165,
+             0.52734917, 0.51432562, 0.50060814, 0.5633982,  0.51509517,
+             0.60189683, 0.56766507, 0.56439768, 0.68919173, 0.57765917,
+             0.60292137, 0.56621788, 0.51913478, 0.48952262, 0.52142782,
+             0.5735005, 0.51166718, 0.57939994, 0.52585236, 0.53767652]
+test_data = [(r[0], w[0], b[0, :, :], n[0, :, :], BQ[0, :, :], Y[0],
+              L[0], K[0], factor, theta, etr_params[-1, :, :, :], p,
+              'SS', expected1),
+             (r, w, b, n, BQ, Y, L, K, factor, theta, etr_params, p,
+              'TPI', expected2)]
+
+
+@pytest.mark.parametrize('r,w,b,n,BQ,Y,L,K,factor,theta,etr_params,p,' +
+                         'method,expected', test_data, ids=['SS', 'TPI'])
+def test_revenue(r, w, b, n, BQ, Y, L, K, factor, theta, etr_params, p,
+                 method, expected):
     """
-    Simulate data similar to observed
+    Test aggregate revenue function.
     """
-    p = Specifications()
-    new_param_values = {
-        'T': 160,
-        'S': 40,
-        'J': 2,
-        'lambdas': [0.6, 0.4],
-    }
-    # update parameters instance with new values for test
-    p.update_specifications(new_param_values, raise_errors=False)
-
-    # make up some consumption values for testing
-    c = 0.1 + 0.5 * np.random.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-    aggC_presum = ((c * np.squeeze(p.lambdas)) *
-                   np.tile(np.reshape(p.omega[:p.T, :], (p.T, p.S, 1)),
-                           (1, 1, p.J)))
-
-    # check that distributional parameters sum to one
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega[:p.T, :].sum(), p.T)
-
-    # test SS
-    aggC = aggr.get_C(c[-1], p, "SS")
-    assert np.allclose(aggC_presum[-1, :, :].sum(), aggC)
-    # test TPI
-    aggC = aggr.get_C(c, p, "TPI")
-    assert np.allclose(aggC_presum.sum(1).sum(1), aggC)
-
-
-def test_revenue():
-    """
-    Simulate data similar to observed and compare current results with saved
-    results
-    """
-    p = Specifications()
-    dim4 = 12
-
-    new_param_values = {
-        'T': 30,
-        'S': 20,
-        'J': 2,
-        'lambdas': [0.6, 0.4],
-        'tau_bq': [0.17],
-        'tau_payroll': [0.5],
-        'h_wealth': [0.1],
-        'p_wealth': [0.2],
-        'm_wealth': [1.0],
-        'tau_b': [0.2],
-        'delta_tau_annual': [float(1 - ((1 - 0.0975) **
-                                       (20 / (p.ending_age -
-                                              p.starting_age))))]
-    }
-    p.update_specifications(new_param_values, raise_errors=False)
-
-    # Assign values to variables for tests
-    random_state = np.random.RandomState(10)
-    r = 0.067 + (0.086 - 0.067) * random_state.rand(p.T)
-    w = 0.866 + (0.927 - 0.866) * random_state.rand(p.T)
-    b = 6.94 * random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J)
-    n = (0.191 + (0.503 - 0.191) *
-         random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
-    BQ = (0.032 + (0.055 - 0.032) *
-          random_state.rand(p.T * p.S * p.J).reshape(p.T, p.S, p.J))
-    Y = 0.561 + (0.602 - 0.561) * random_state.rand(p.T).reshape(p.T)
-    L = 0.416 + (0.423 - 0.416) * random_state.rand(p.T).reshape(p.T)
-    K = 0.957 + (1.163 - 0.957) * random_state.rand(p.T).reshape(p.T)
-    factor = 140000.0
-
-    # update parameters instance with new values for test
-    p.e = (0.263 + (2.024 - 0.263) *
-           random_state.rand(p.S * p.J).reshape(p.S, p.J))
-    p.omega = 0.039 * random_state.rand(p.T * p.S * 1).reshape(p.T, p.S)
-    p.omega = p.omega/p.omega.sum(axis=1).reshape(p.T, 1)
-    p.omega_SS = p.omega[-1, :]
-
-    etr_params = (0.22 *
-                  random_state.rand(p.T * p.S * dim4).reshape(p.T, p.S,
-                                                              dim4))
-    etr_params = np.tile(np.reshape(etr_params, (p.T, p.S, 1, dim4)),
-                         (1, 1, p.J, 1))
-    theta = 0.101 + (0.156 - 0.101) * random_state.rand(p.J)
-
-    # check that distributional parameters sum to one
-    assert np.allclose(p.lambdas.sum(), 1.0)
-    assert np.allclose(p.omega[:p.T, :].sum(), p.T)
-
-    # SS case
-    method = "SS"
-    res = aggr.revenue(r[0], w[0], b[0, :, :], n[0, :, :], BQ[0, :, :],
-                       Y[0], L[0], K[0], factor, theta,
-                       etr_params[-1, :, :, :], p, method)
-    assert(np.allclose(res,  0.5562489534339288))
-
-    # TPI case
-    method = "TPI"
-    res = aggr.revenue(r, w, b, n, BQ, Y, L, K, factor, theta,
-                       etr_params, p, method)
-    test = [0.52178543, 0.49977116, 0.52015768, 0.52693363, 0.59695398,
-            0.61360011, 0.54679056, 0.54096669, 0.56301133, 0.5729165,
-            0.52734917, 0.51432562, 0.50060814, 0.5633982,  0.51509517,
-            0.60189683, 0.56766507, 0.56439768, 0.68919173, 0.57765917,
-            0.60292137, 0.56621788, 0.51913478, 0.48952262, 0.52142782,
-            0.5735005, 0.51166718, 0.57939994, 0.52585236, 0.53767652]
-    assert(np.allclose(res, test))
+    revenue, _, _, _, _, _ = aggr.revenue(r, w, b, n, BQ, Y, L, K,
+                                          factor, theta, etr_params, p,
+                                          method)
+    assert(np.allclose(revenue, expected))

--- a/ogusa/tests/test_basic.py
+++ b/ogusa/tests/test_basic.py
@@ -69,7 +69,8 @@ def test_import_ok():
     import ogusa
 
 
-def test_run_small_SS():
+@pytest.mark.parametrize('time_path', [False, True], ids=['SS', 'TPI'])
+def test_run_small(time_path):
     from ogusa.execute import runner
     # Monkey patch enforcement flag since small data won't pass checks
     SS.ENFORCE_SOLUTION_CHECKS = False
@@ -80,22 +81,7 @@ def test_run_small_SS():
     input_dir = "./OUTPUT"
     user_params = {'frisch': 0.41, 'debt_ratio_ss': 0.4}
     runner(output_base=output_base, baseline_dir=input_dir, test=True,
-           time_path=False, baseline=True, user_params=user_params,
-           run_micro=False)
-
-
-def test_run_small_TPI():
-    from ogusa.execute import runner
-    # Monkey patch enforcement flag since small data won't pass checks
-    SS.ENFORCE_SOLUTION_CHECKS = False
-    TPI.ENFORCE_SOLUTION_CHECKS = False
-    SS.MINIMIZER_TOL = 1e-6
-    TPI.MINIMIZER_TOL = 1e-6
-    output_base = "./OUTPUT"
-    input_dir = "./OUTPUT"
-    user_params = {'frisch': 0.41, 'debt_ratio_ss': 0.4}
-    runner(output_base=output_base, baseline_dir=input_dir, test=True,
-           time_path=True, baseline=True, user_params=user_params,
+           time_path=time_path, baseline=True, user_params=user_params,
            run_micro=False)
 
 
@@ -244,7 +230,6 @@ def test_compare_dict_diff_ndarrays_relative():
 
 
 def test_get_micro_data_get_calculator():
-
     reform = {
         2017: {
             '_II_rt1': [.09],
@@ -261,20 +246,3 @@ def test_get_micro_data_get_calculator():
                           weights=WEIGHTS,
                           records_start_year=CPS_START_YEAR)
     assert calc.current_year == 2017
-
-    reform = {
-        2017: {
-            '_II_rt1': [.09],
-            '_II_rt2': [.135],
-            '_II_rt3': [.225],
-            '_II_rt4': [.252],
-            '_II_rt5': [.297],
-            '_II_rt6': [.315],
-            '_II_rt7': [0.3564]
-        }, }
-
-    calc2 = get_calculator(baseline=False, calculator_start_year=2017,
-                           reform=reform, data=TAXDATA,
-                           weights=WEIGHTS,
-                           records_start_year=CPS_START_YEAR)
-    assert calc2.current_year == 2017


### PR DESCRIPTION
This PR makes the simple change of returning the aggregates amounts for each tax source from `aggregates.revenue()` and then saving these results to the SS and TP output dictionaries.

The `test_aggregates.py` tests are also streamlined by using the `mark.parameterize` decorator.

