### PR TITLE
Miscellaneous fixes

### DIFF
--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -706,7 +706,7 @@ def run_SS(p, client=None):
         factorguess = 70000
         BQguess = aggr.get_BQ(rguess, b_guess, None, p, 'SS', False)
         ss_params_baseline = (b_guess, n_guess, None, None, p, client)
-        guesses = [rguess] + list(BQguess) + [T_Hguess, factorguess]
+        guesses = [rguess] + list(np.array([BQguess])) + [T_Hguess, factorguess]
         [solutions_fsolve, infodict, ier, message] =\
             opt.fsolve(SS_fsolve, guesses, args=ss_params_baseline,
                        xtol=p.mindist_SS, full_output=True)
@@ -734,14 +734,8 @@ def run_SS(p, client=None):
              ss_solutions['factor_ss'])
         if p.baseline_spending:
             T_Hss = T_Hguess
-            # ss_params_reform = (b_guess, n_guess, T_Hss, factor, p, client)
-            # guesses = [rguess, Yguess]
-            # [solutions_fsolve, infodict, ier, message] =\
-            #     opt.fsolve(SS_fsolve_reform_baselinespend, guesses,
-            #                args=ss_params_reform, xtol=p.mindist_SS,
-            #                full_output=True)
             ss_params_reform = (b_guess, n_guess, T_Hss, factor, p, client)
-            guesses = [rguess] + list(BQguess) + [Yguess]
+            guesses = [rguess] + list(np.array([BQguess])) + [Yguess]
             [solutions_fsolve, infodict, ier, message] =\
                 opt.fsolve(SS_fsolve, guesses,
                            args=ss_params_reform, xtol=p.mindist_SS,
@@ -750,14 +744,8 @@ def run_SS(p, client=None):
             BQss = solutions_fsolve[1:-1]
             Yss = solutions_fsolve[-1]
         else:
-            # ss_params_reform = (b_guess, n_guess, factor, p, client)
-            # guesses = [rguess, T_Hguess]
-            # [solutions_fsolve, infodict, ier, message] =\
-            #     opt.fsolve(SS_fsolve_reform, guesses,
-            #                args=ss_params_reform, xtol=p.mindist_SS,
-            #                full_output=True)
             ss_params_reform = (b_guess, n_guess, None, factor, p, client)
-            guesses = [rguess] + list(BQguess) + [T_Hguess]
+            guesses = [rguess] + list(np.array([BQguess])) + [T_Hguess]
             [solutions_fsolve, infodict, ier, message] =\
                 opt.fsolve(SS_fsolve, guesses,
                            args=ss_params_reform, xtol=p.mindist_SS,

--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -698,10 +698,9 @@ def run_SS(p, client=None):
     # For initial guesses of w, r, T_H, and factor, we use values that
     # are close to some steady state values.
     if p.baseline:
-        b_guess = np.ones((p.S, p.J)) * 0.05
+        b_guess = np.ones((p.S, p.J)) * 0.07
         n_guess = np.ones((p.S, p.J)) * .4 * p.ltilde
-        rguess = 0.05  # 0.01 + delta
-        # wguess = 1.2
+        rguess = 0.09
         T_Hguess = 0.12
         factorguess = 70000
         BQguess = aggr.get_BQ(rguess, b_guess, None, p, 'SS', False)

--- a/ogusa/SS.py
+++ b/ogusa/SS.py
@@ -705,7 +705,10 @@ def run_SS(p, client=None):
         factorguess = 70000
         BQguess = aggr.get_BQ(rguess, b_guess, None, p, 'SS', False)
         ss_params_baseline = (b_guess, n_guess, None, None, p, client)
-        guesses = [rguess] + list(np.array([BQguess])) + [T_Hguess, factorguess]
+        if p.use_zeta:
+            guesses = [rguess] + list([BQguess]) + [T_Hguess, factorguess]
+        else:
+            guesses = [rguess] + list(BQguess) + [T_Hguess, factorguess]
         [solutions_fsolve, infodict, ier, message] =\
             opt.fsolve(SS_fsolve, guesses, args=ss_params_baseline,
                        xtol=p.mindist_SS, full_output=True)
@@ -734,7 +737,10 @@ def run_SS(p, client=None):
         if p.baseline_spending:
             T_Hss = T_Hguess
             ss_params_reform = (b_guess, n_guess, T_Hss, factor, p, client)
-            guesses = [rguess] + list(np.array([BQguess])) + [Yguess]
+            if p.use_zeta:
+                guesses = [rguess] + list([BQguess]) + [Yguess]
+            else:
+                guesses = [rguess] + list(BQguess) + [Yguess]
             [solutions_fsolve, infodict, ier, message] =\
                 opt.fsolve(SS_fsolve, guesses,
                            args=ss_params_reform, xtol=p.mindist_SS,
@@ -744,7 +750,10 @@ def run_SS(p, client=None):
             Yss = solutions_fsolve[-1]
         else:
             ss_params_reform = (b_guess, n_guess, None, factor, p, client)
-            guesses = [rguess] + list(np.array([BQguess])) + [T_Hguess]
+            if p.use_zeta:
+                guesses = [rguess] + list([BQguess]) + [T_Hguess]
+            else:
+                guesses = [rguess] + list(BQguess) + [T_Hguess]
             [solutions_fsolve, infodict, ier, message] =\
                 opt.fsolve(SS_fsolve, guesses,
                            args=ss_params_reform, xtol=p.mindist_SS,

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -446,16 +446,16 @@ def run_TPI(p, client=None):
     w[:p.T] = firm.get_w_from_r(r[:p.T], p, 'TPI')
     w[p.T:] = wss
 
-    BQ = np.zeros((p.T + p.S, p.J))
     BQ0 = aggr.get_BQ(r[0], initial_b, None, p, 'SS', True)
     if not p.use_zeta:
+        BQ = np.zeros((p.T + p.S, p.J))
         for j in range(p.J):
             BQ[:, j] = (list(np.linspace(BQ0[j], BQss[j], p.T)) +
                         [BQss[j]] * p.S)
         BQ = np.array(BQ)
     else:
-        BQ += BQss
-        BQ[0] = BQ0
+        BQ = (list(np.linspace(BQ0, BQss, p.T)) + [BQss] * p.S)
+        BQ = np.array(BQ)
     if p.budget_balance:
         if np.abs(T_Hss) < 1e-13:
             T_Hss2 = 0.0  # sometimes SS is very small but not zero,

--- a/ogusa/demographics.py
+++ b/ogusa/demographics.py
@@ -109,7 +109,7 @@ def get_fert(totpers, min_yr, max_yr, graph=False):
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     pop_file = utils.read_file(cur_path,
                                "data/demographic/pop_data.csv")
-    pop_data = pd.read_table(pop_file, sep=',', thousands=',')
+    pop_data = pd.read_csv(pop_file, sep=',', thousands=',')
     pop_data_samp = pop_data[(pop_data['Age'] >= min_yr - 1) &
                              (pop_data['Age'] <= max_yr - 1)]
     curr_pop = np.array(pop_data_samp['2013'], dtype='f')
@@ -270,7 +270,7 @@ def get_mort(totpers, min_yr, max_yr, graph=False):
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     mort_file = utils.read_file(
         cur_path, 'data/demographic/mort_rates2011.csv')
-    mort_data = pd.read_table(mort_file, sep=',', thousands=',')
+    mort_data = pd.read_csv(mort_file, sep=',', thousands=',')
     age_year_all = mort_data['Age'] + 1
     mort_rates_all = (
         ((mort_data['Male Mort. Rate'] * mort_data['Num. Male Lives']) +
@@ -474,7 +474,7 @@ def get_imm_resid(totpers, min_yr, max_yr, graph=True):
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     pop_file = utils.read_file(cur_path,
                                "data/demographic/pop_data.csv")
-    pop_data = pd.read_table(pop_file, sep=',', thousands=',')
+    pop_data = pd.read_csv(pop_file, sep=',', thousands=',')
     pop_data_samp = pop_data[(pop_data['Age'] >= min_yr - 1) &
                              (pop_data['Age'] <= max_yr - 1)]
     pop_2010, pop_2011, pop_2012, pop_2013 = (
@@ -722,7 +722,7 @@ def get_pop_objs(E, S, T, min_yr, max_yr, curr_year, GraphDiag=True):
     cur_path = os.path.split(os.path.abspath(__file__))[0]
     pop_file = utils.read_file(cur_path,
                                "data/demographic/pop_data.csv")
-    pop_data = pd.read_table(pop_file, sep=',', thousands=',')
+    pop_data = pd.read_csv(pop_file, sep=',', thousands=',')
     pop_data_samp = pop_data[(pop_data['Age'] >= min_yr - 1) &
                              (pop_data['Age'] <= max_yr - 1)]
     pop_2013 = np.array(pop_data_samp['2013'], dtype='f')

--- a/ogusa/household.py
+++ b/ogusa/household.py
@@ -32,7 +32,7 @@ def marg_ut_cons(c, sigma):
     '''
     if np.ndim(c) == 0:
         c = np.array([c])
-    epsilon = 0.0001
+    epsilon = 0.003
     cvec_cnstr = c < epsilon
     MU_c = np.zeros(c.shape)
     MU_c[~cvec_cnstr] = c[~cvec_cnstr] ** (-sigma)

--- a/ogusa/household.py
+++ b/ogusa/household.py
@@ -142,7 +142,7 @@ def get_bq(BQ, j, p, method):
                 bq = ((np.reshape(p.zeta, (1, p.S, p.J)) *
                       utils.to_timepath_shape(BQ, p)) /
                       (p.lambdas.reshape((1, 1, p.J)) *
-                       p.omega.reshape((len_T, p.S, 1))))
+                       p.omega[:len_T, :].reshape((len_T, p.S, 1))))
     else:
         if j is not None:
             if method == 'SS':

--- a/ogusa/tests/test_household.py
+++ b/ogusa/tests/test_household.py
@@ -460,7 +460,7 @@ test_vars_tpi = (r_vec, w_vec, b_path, b_splus1_path, n_path, bq_vec,
                  mtrx_params_tpi, 0, j, method_tpi)
 expected_tpi = np.array([[72.47245852, 0.021159855, 0.448785988],
                          [52.98670445, 2.020513233, -0.319957296],
-                         [1.00982611e+09, 0.238114178, -0.131132485]])
+                         [2.12409207e+05, 0.238114178, -0.131132485]])
 
 # Define variables/params for test of TPI version
 method_tpi = 'TPI'
@@ -474,7 +474,7 @@ test_params_tau_pay.tau_bq = np.array([0.0, 0.0, 0.0])
 expected_tau_pay = np.array(
     [[29.60252043, 0.039791027, 0.464569438],
      [15.37208418, 1.814624637, -0.179212251],
-     [1.43082652e+09, 0.158962139, -0.41924639]])
+     [2.95870445e+05, 0.158962139, -0.41924639]])
 
 test_data = [(test_vars_ss, test_params_ss, expected_ss),
              (test_vars_tpi, test_params_tpi, expected_tpi),


### PR DESCRIPTION
This PR makes a few minor fixes:
1) Replace the deprecated `pandas.read_tables()` calls in `demographics.py`
2) Fixes in `SS.py` and `household.py` and `TPI.py` for diff shapes of BQ when using zeta matrix.
3) Change `epsilon` value in `household.marg_ut_cons()`, which seems to help with model robustness.
4) Update initial guesses in `SS.py` to help with robustness of model solution.