### PR TITLE
Changed pd.read_table to pd.read_csv in two files

### DIFF
--- a/ogusa/labor.py
+++ b/ogusa/labor.py
@@ -65,7 +65,7 @@ def get_labor_data():
 #
 #     labor_file = utils.read_file(cur_path,
 #                                  "data/labor/cps_hours_by_age_hourspct.txt")
-#     data = pd.read_table(labor_file, header=0)
+#     data = pd.read_csv(labor_file, header=0)
 #
 #     piv = data.pivot(index='age', columns='hours_pct', values='mean_hrs')
 #     lab_mat_basic = np.array(piv)

--- a/ogusa/wealth.py
+++ b/ogusa/wealth.py
@@ -43,7 +43,7 @@ def get_wealth_data():
     # read in SCF data collapsed by age and percentile for graphs
     wealth_file = utils.read_file(
         cur_path, "data/wealth/scf2007to2013_wealth_age_all_percentiles.csv")
-    data = pd.read_table(wealth_file, sep=',', header=0)
+    data = pd.read_csv(wealth_file, sep=',', header=0)
 
     # read in raw SCF data to calculate moments
     fileDir = os.path.dirname(os.path.realpath('__file__'))


### PR DESCRIPTION
Changed depreciated `pd.read_table` command in `labor.py` and `wealth.py` to `pd.read_csv`. Neither file is currently called by OG-USA. But they are useful for thinking about calibration.
@jdebacker 