### PR TITLE
Update reform json to work with latest TC

### DIFF
--- a/run_examples/2017_law.json
+++ b/run_examples/2017_law.json
@@ -1,61 +1,125 @@
 // Title: 2017-law policy extrapolated into the future as if under pre-TCJA law
 // Reform_File_Author: Martin Holmer and Cody Kallen
-// Reform_Reference: 
+// Reform_Reference:
 // Reform_Baseline: current_law_policy.json
 // Reform_Description:
 // - Switch to unchained CPI-U calculation of 2018+ policy parameter values (0)
-// - Set pre-TCJA tax rates (1)
+// - Set pre-TCJA tax rates and brackets (1)
 // - Set pre-TCJA handling of pass-through income (2)
-// - Set pre-TCJA child tax credit (CTC) and additional CTC policy (3)
-// - Set pre-TCJA dependent credit policy parameters (4)
-// - Set pre-TCJA above the line deduction policy (5)
-// - Set pre-TCJA itemized deduction policy (6)
+// - Set pre-TCJA standard deduction and personal exemption (3)
+// - Set pre-TCJA child tax credit (CTC) and additional CTC policy (4)
+// - Set pre-TCJA other dependent credit policy parameters (5)
+// - Set pre-TCJA AMT exemption parameters (6)
+// - Set pre-TCJA above the line deduction policy (7)
+// - Set pre-TCJA itemized deduction policy (8)
 // Reform_Parameter_Map:
 // - 0: _cpi_offset
-// - 1: _II_rt? and _PT_rt?
+// - 1: _II_rt?/_II_brk? and _PT_rt?/_PT_brk?
 // - 2: four _PT_excl_* parameters
-// - 3: _CTC_c and _CTC_ps and _ACTC_Income_thd
-// - 4: three different _DependentCredit_* parameters
-// - 5: three _ALD_* parameters
-// - 6: seven different _ID_* parameters
+// - 3: _STD and _II_em parameters
+// - 4: _CTC_* and _ACTC_* parameters
+// - 5: _ODC_c parameter
+// - 6: three different _AMT_em* parameters
+// - 7: three _ALD_* parameters
+// - 8: seven different _ID_* parameters
+// - 9: many parameters not altered by TCJA except for indexing change
 // NOTE: this reform projects pre-TCJA 2017 parameter values forward using the
 //       unchained CPI-U price index.
 {
     "policy": {
         "_cpi_offset": {"2017": [0.0025]},
         "_II_rt1": {"2018": [0.10]},
+        "_II_brk1": {"2017": [[9325, 18650, 9325, 13350, 18650]]},
         "_II_rt2": {"2018": [0.15]},
+        "_II_brk2": {"2017": [[37950, 75900, 37950, 50800, 75900]]},
         "_II_rt3": {"2018": [0.25]},
+        "_II_brk3": {"2017": [[91900, 153100, 76550, 131200, 153100]]},
         "_II_rt4": {"2018": [0.28]},
+        "_II_brk4": {"2017": [[191650, 233350, 116675, 212500, 233350]]},
         "_II_rt5": {"2018": [0.33]},
+        "_II_brk5": {"2017": [[416700, 416700, 208350, 416700, 416700]]},
         "_II_rt6": {"2018": [0.35]},
+        "_II_brk6": {"2017": [[418400, 470700, 235350, 444550, 470700]]},
         "_II_rt7": {"2018": [0.396]},
         "_PT_rt1": {"2018": [0.10]},
+        "_PT_brk1": {"2017": [[9325, 18650, 9325, 13350, 18650]]},
         "_PT_rt2": {"2018": [0.15]},
+        "_PT_brk2": {"2017": [[37950, 75900, 37950, 50800, 75900]]},
         "_PT_rt3": {"2018": [0.25]},
+        "_PT_brk3": {"2017": [[91900, 153100, 76550, 131200, 153100]]},
         "_PT_rt4": {"2018": [0.28]},
+        "_PT_brk4": {"2017": [[191650, 233350, 116675, 212500, 233350]]},
         "_PT_rt5": {"2018": [0.33]},
+        "_PT_brk5": {"2017": [[416700, 416700, 208350, 416700, 416700]]},
         "_PT_rt6": {"2018": [0.35]},
+        "_PT_brk6": {"2017": [[418400, 470700, 235350, 444550, 470700]]},
         "_PT_rt7": {"2018": [0.396]},
-        "_PT_excl_rt": {"2018": [0.0]},
+        "_PT_excl_rt": {"2018": [0]},
         "_PT_excl_wagelim_rt": {"2018": [9e99]},
-        "_PT_excl_wagelim_thd": {"2018": [[0.0, 0.0, 0.0, 0.0, 0.0]]},
-        "_PT_excl_wagelim_prt": {"2018": [[0.0, 0.0, 0.0, 0.0, 0.0]]},
-        "_CTC_c": {"2018": [1000.0]},
-        "_CTC_ps": {"2018": [[75000.0, 110000.0, 55000.0, 75000.0, 75000.0]]},
-        "_ACTC_Income_thd": {"2018": [3000.0]},
-        "_DependentCredit_Child_c": {"2018": [0.0]},
-        "_DependentCredit_Nonchild_c": {"2018": [0.0]},
-        "_DependentCredit_before_CTC": {"2018": [false]},
-        "_ALD_AlimonyPaid_hc": {"2019": [0.0]},
-        "_ALD_AlimonyReceived_hc": {"2019": [1.0]},
-        "_ALD_DomesticProduction_hc": {"2018": [0.0]},
+        "_PT_excl_wagelim_thd": {"2018": [[0, 0, 0, 0, 0]]},
+        "_PT_excl_wagelim_prt": {"2018": [[0, 0, 0, 0, 0]]},
+        "_STD": {"2017": [[6350, 12700, 6350, 9350, 12700]]},
+        "_II_em": {"2017": [4050]},
+        "_CTC_c": {"2018": [1000]},
+        "_CTC_ps": {"2018": [[75000, 110000, 55000, 75000, 75000]]},
+        "_ACTC_c": {"2018": [1000]},
+        "_ACTC_Income_thd": {"2018": [3000]},
+        "_ODC_c": {"2018": [0]},
+        "_AMT_em": {"2017": [[54300, 84500, 42250, 54300, 84500]]},
+        "_AMT_em_ps": {"2017": [[120700, 160900, 80450, 120700, 160900]]},
+        "_AMT_em_pe": {"2017": [249450]},
+        "_ALD_BusinessLosses_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ALD_AlimonyPaid_hc": {"2019": [0]},
+        "_ALD_AlimonyReceived_hc": {"2019": [1]},
+        "_ALD_DomesticProduction_hc": {"2018": [0]},
         "_ID_prt": {"2018": [0.03]},
-        "_ID_crt": {"2018": [0.8]},
+        "_ID_crt": {"2018": [0.80]},
         "_ID_Charity_crt_all": {"2018": [0.5]},
-        "_ID_Casualty_hc": {"2018": [0.0]},
+        "_ID_Casualty_hc": {"2018": [0]},
         "_ID_AllTaxes_c": {"2018": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
-        "_ID_Miscellaneous_hc": {"2018": [0.0]},
-        "_ID_Medical_frt": {"2017": [0.1]}
+        "_ID_Miscellaneous_hc": {"2018": [0]},
+        "_ID_Medical_frt": {"2017": [0.1]},
+
+        "_ALD_Dependents_Child_c": {"2017": [0]},
+        "_ALD_Dependents_Elder_c": {"2017": [0]},
+        "_II_em_ps": {"2017": [[261500, 313800, 156900, 287650, 313800]]},
+        "_STD_Dep": {"2017": [1050]},
+        "_STD_Aged": {"2017": [[1550, 1250, 1250, 1550, 1550]]},
+        "_II_credit": {"2017": [[0, 0, 0, 0, 0]]},
+        "_II_credit_ps": {"2017": [[0, 0, 0, 0, 0]]},
+        "_II_credit_nr": {"2017": [[0, 0, 0, 0, 0]]},
+        "_II_credit_nr_ps": {"2017": [[0, 0, 0, 0, 0]]},
+        "_ID_Medical_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_StateLocalTax_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_RealEstate_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_InterestPaid_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_Charity_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_Casualty_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_Miscellaneous_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_ID_ps": {"2017": [[261500, 313800, 156900, 287650, 313800]]},
+        "_ID_BenefitSurtax_em": {"2017": [[0, 0, 0, 0, 0]]},
+        "_ID_c": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_CG_brk1": {"2017": [[37950, 75900, 37950, 50800, 75900]]},
+        "_CG_brk2": {"2017": [[418400, 470700, 235350, 444550, 470700]]},
+        "_CG_brk3": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_AMT_CG_brk1": {"2017": [[37950, 75900, 37950, 50800, 75900]]},
+        "_AMT_CG_brk2": {"2017": [[418400, 470700, 235350, 444550, 470700]]},
+        "_AMT_CG_brk3": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_CG_ec": {"2017": [0]},
+        "_AMT_child_em": {"2017": [7500]},
+        "_AMT_brk1": {"2017": [187800]},
+        "_EITC_c": {"2017": [[510, 3400, 5616, 6318]]},
+        "_EITC_ps": {"2017": [[8340, 18340, 18340, 18340]]},
+        "_EITC_ps_MarriedJ": {"2017": [[5600, 5600, 5600, 5600]]},
+        "_EITC_InvestIncome_c": {"2017": [3450]},
+        "_ETC_pe_Single": {"2017": [66]},
+        "_ETC_pe_Married": {"2017": [132]},
+        "_CTC_new_ps": {"2017": [[0, 0, 0, 0, 0]]},
+        "_FST_AGI_thd_lo": {"2017": [[1.0e6, 1.0e6, 0.5e6, 1.0e6, 1.0e6]]},
+        "_FST_AGI_thd_hi": {"2017": [[2.0e6, 2.0e6, 1.0e6, 2.0e6, 2.0e6]]},
+        "_AGI_surtax_thd": {"2017": [[9e99, 9e99, 9e99, 9e99, 9e99]]},
+        "_UBI_u18": {"2017": [0]},
+        "_UBI_1820": {"2017": [0]},
+        "_UBI_21": {"2017": [0]}
     }
 }


### PR DESCRIPTION
This PR updates the `reform_2017.json` file to work with the latest TC releases in which some parameter names were changed.