### PR TITLE
Update TC dict in test

### DIFF
--- a/ogusa/tests/test_basic.py
+++ b/ogusa/tests/test_basic.py
@@ -231,15 +231,14 @@ def test_compare_dict_diff_ndarrays_relative():
 
 def test_get_micro_data_get_calculator():
     reform = {
-        2017: {
-            'II_rt1': [.09],
-            'II_rt2': [.135],
-            'II_rt3': [.225],
-            'II_rt4': [.252],
-            'II_rt5': [.297],
-            'II_rt6': [.315],
-            'II_rt7': [0.3564],
-        }, }
+        'II_rt1': {2017: 0.09},
+        'II_rt2': {2017: 0.135},
+        'II_rt3': {2017: 0.225},
+        'II_rt4': {2017: 0.252},
+        'II_rt5': {2017: 0.297},
+        'II_rt6': {2017: 0.315},
+        'II_rt7': {2017: 0.3564}
+        }
 
     calc = get_calculator(baseline=False, calculator_start_year=2017,
                           reform=reform, data=TAXDATA,

--- a/ogusa/tests/test_basic.py
+++ b/ogusa/tests/test_basic.py
@@ -232,13 +232,13 @@ def test_compare_dict_diff_ndarrays_relative():
 def test_get_micro_data_get_calculator():
     reform = {
         2017: {
-            '_II_rt1': [.09],
-            '_II_rt2': [.135],
-            '_II_rt3': [.225],
-            '_II_rt4': [.252],
-            '_II_rt5': [.297],
-            '_II_rt6': [.315],
-            '_II_rt7': [0.3564],
+            'II_rt1': [.09],
+            'II_rt2': [.135],
+            'II_rt3': [.225],
+            'II_rt4': [.252],
+            'II_rt5': [.297],
+            'II_rt6': [.315],
+            'II_rt7': [0.3564],
         }, }
 
     calc = get_calculator(baseline=False, calculator_start_year=2017,

--- a/ogusa/tests/test_data.py
+++ b/ogusa/tests/test_data.py
@@ -10,7 +10,7 @@ def test_cps():
     from ogusa import get_micro_data
     baseline = False
     start_year = 2016
-    reform = {2017: {"_II_em": [10000]}}
+    reform = {"II_em": {2017: 10000}}
 
     calc = get_micro_data.get_calculator(
         baseline, start_year, reform=reform,
@@ -48,7 +48,7 @@ def test_puf_path():
     from ogusa import get_micro_data
     baseline = False
     start_year = 2016
-    reform = {2017: {"_II_em": [10000]}}
+    reform = {"II_em": {2017: 10000}}
 
     # get path to puf if puf.csv in ogusa/ directory
     cur_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR addresses Issue #458.  It updates the reform dictionary specified in `test_basic.test_get_micro_data_get_calculator()` to be compatible with Tax Calculator 2.0.