### PR TITLE
Clean txfunc py

### DIFF
--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -1046,21 +1046,21 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
     ----------------------------------------------------------------
     '''
     # initialize arrays for output
-    etrparam_arr = np.zeros((s_max - s_min + 1, tpers, numparams))
-    mtrxparam_arr = np.zeros((s_max - s_min + 1, tpers, numparams))
-    mtryparam_arr = np.zeros((s_max - s_min + 1, tpers, numparams))
-    etr_wsumsq_arr = np.zeros((s_max - s_min + 1, tpers))
-    etr_obs_arr = np.zeros((s_max - s_min + 1, tpers))
-    mtrx_wsumsq_arr = np.zeros((s_max - s_min + 1, tpers))
-    mtrx_obs_arr = np.zeros((s_max - s_min + 1, tpers))
-    mtry_wsumsq_arr = np.zeros((s_max - s_min + 1, tpers))
-    mtry_obs_arr = np.zeros((s_max - s_min + 1, tpers))
-    AvgInc = np.zeros(tpers)
-    AvgETR = np.zeros(tpers)
-    AvgMTRx = np.zeros(tpers)
-    AvgMTRy = np.zeros(tpers)
-    TotPop_yr = np.zeros(tpers)
-    PopPct_age = np.zeros((s_max - s_min + 1, tpers))
+    etrparam_arr = np.zeros((s_max - s_min + 1, t-start_year, numparams))
+    mtrxparam_arr = np.zeros((s_max - s_min + 1, t-start_year, numparams))
+    mtryparam_arr = np.zeros((s_max - s_min + 1, t-start_year, numparams))
+    etr_wsumsq_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    etr_obs_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    mtrx_wsumsq_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    mtrx_obs_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    mtry_wsumsq_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    mtry_obs_arr = np.zeros((s_max - s_min + 1, t-start_year))
+    AvgInc = np.zeros(t-start_year)
+    AvgETR = np.zeros(t-start_year)
+    AvgMTRx = np.zeros(t-start_year)
+    AvgMTRy = np.zeros(t-start_year)
+    TotPop_yr = np.zeros(t-start_year)
+    PopPct_age = np.zeros((s_max - s_min + 1, t-start_year))
 
     micro_data['Total labor income'] = \
         (micro_data['Wage income'] + micro_data['SE income'])
@@ -1089,29 +1089,29 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
     del micro_data
 
     # Calculate average total income in each year
-    AvgInc[t-start_year] = \
+    AvgInc= \
         (((data['Adjusted total income'] * data['Weights']).sum())
          / data['Weights'].sum())
 
     # Calculate average ETR and MTRs (weight by population weights
     #    and income) for each year
-    AvgETR[t-start_year] = \
+    AvgETR = \
         (((data['ETR']*data['Adjusted total income']
            * data['Weights']).sum()) /
          (data['Adjusted total income']*data['Weights']).sum())
 
-    AvgMTRx[t-start_year] = \
+    AvgMTRx = \
         (((data['MTR labor income']*data['Adjusted total income'] *
            data['Weights']).sum()) /
          (data['Adjusted total income']*data['Weights']).sum())
 
-    AvgMTRy[t-start_year] = \
+    AvgMTRy = \
         (((data['MTR capital income'] *
            data['Adjusted total income'] * data['Weights']).sum()) /
          (data['Adjusted total income']*data['Weights']).sum())
 
     # Calculate total population in each year
-    TotPop_yr[t-start_year] = data['Weights'].sum()
+    TotPop_yr = data['Weights'].sum()
 
     # Clean up the data by dropping outliers
     # drop all obs with ETR > 0.65
@@ -1150,13 +1150,13 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
             print("year=", t, "Age=", s)
             df = data[data['Age'] == s]
             PopPct_age[s-min_age, t-start_year] = \
-                df['Weights'].sum() / TotPop_yr[t-start_year]
+                df['Weights'].sum() / TotPop_yr
 
         else:
             print("year=", t, "Age= all ages")
             df = data
             PopPct_age[0, t-start_year] = \
-                df['Weights'].sum() / TotPop_yr[t-start_year]
+                df['Weights'].sum() / TotPop_yr
         df_etr = df.loc[df[
             (np.isfinite(df['ETR'])) &
             (np.isfinite(df['Total labor income'])) &
@@ -1194,9 +1194,9 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                        " in year " + str(t))
             print(message)
             NoData_cnt += 1
-            etrparam_arr[s-s_min, t-start_year, :] = np.nan
-            mtrxparam_arr[s-s_min, t-start_year, :] = np.nan
-            mtryparam_arr[s-s_min, t-start_year, :] = np.nan
+            etrparam_arr[s-s_min, :, :] = np.nan
+            mtrxparam_arr[s-s_min, :, :] = np.nan
+            mtryparam_arr[s-s_min, :, :] = np.nan
 
         elif df_minobs < 240 and s == max_age:
             '''
@@ -1223,18 +1223,18 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
             print(message)
             NoData_cnt += 1
             lastp_etr = \
-                etrparam_arr[s-NoData_cnt-s_min, t-start_year, :]
-            etrparam_arr[s-NoData_cnt-s_min+1:, t-start_year, :] = \
+                etrparam_arr[s-NoData_cnt-s_min,:, :]
+            etrparam_arr[s-NoData_cnt-s_min+1:,:, :] = \
                 np.tile(lastp_etr.reshape((1, numparams)),
                         (NoData_cnt+s_max-max_age, 1))
             lastp_mtrx = \
-                mtrxparam_arr[s-NoData_cnt-s_min, t-start_year, :]
-            mtrxparam_arr[s-NoData_cnt-s_min+1:, t-start_year, :] = \
+                mtrxparam_arr[s-NoData_cnt-s_min,:, :]
+            mtrxparam_arr[s-NoData_cnt-s_min+1:, :, :] = \
                 np.tile(lastp_mtrx.reshape((1, numparams)),
                         (NoData_cnt+s_max-max_age, 1))
             lastp_mtry = \
-                mtryparam_arr[s-NoData_cnt-s_min, t-start_year, :]
-            mtryparam_arr[s-NoData_cnt-s_min+1:, t-start_year, :] = \
+                mtryparam_arr[s-NoData_cnt-s_min, :, :]
+            mtryparam_arr[s-NoData_cnt-s_min+1:, :, :] = \
                 np.tile(lastp_mtry.reshape((1, numparams)),
                         (NoData_cnt+s_max-max_age, 1))
 
@@ -1259,28 +1259,28 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                 gen_3Dscatters_hist(df_etr, s, t, output_dir)
 
             # Estimate effective tax rate function ETR(x,y)
-            (etrparams, etr_wsumsq_arr[s-s_min, t-start_year],
-                etr_obs_arr[s-s_min, t-start_year]) = \
+            (etrparams, etr_wsumsq_arr[s-s_min, :],
+                etr_obs_arr[s-s_min, :]) = \
                 txfunc_est(df_etr, s, t, 'etr', tax_func_type,
                            numparams, output_dir, graph_est)
-            etrparam_arr[s-s_min, t-start_year, :] = etrparams
+            etrparam_arr[s-s_min, :, :] = etrparams
             del df_etr
 
             # Estimate marginal tax rate of labor income function
             # MTRx(x,y)
-            (mtrxparams, mtrx_wsumsq_arr[s-s_min, t-start_year],
-                mtrx_obs_arr[s-s_min, t-start_year]) = \
+            (mtrxparams, mtrx_wsumsq_arr[s-s_min, :],
+                mtrx_obs_arr[s-s_min, :]) = \
                 txfunc_est(df_mtrx, s, t, 'mtrx', tax_func_type,
                            numparams, output_dir, graph_est)
-            mtrxparam_arr[s-s_min, t-start_year, :] = mtrxparams
+            mtrxparam_arr[s-s_min, :, :] = mtrxparams
             del df_mtrx
             # Estimate marginal tax rate of capital income function
             # MTRy(x,y)
-            (mtryparams, mtry_wsumsq_arr[s-s_min, t-start_year],
-                mtry_obs_arr[s-s_min, t-start_year]) = \
+            (mtryparams, mtry_wsumsq_arr[s-s_min, :],
+                mtry_obs_arr[s-s_min, :]) = \
                 txfunc_est(df_mtry, s, t, 'mtry', tax_func_type,
                            numparams, output_dir, graph_est)
-            mtryparam_arr[s-s_min, t-start_year, :] = mtryparams
+            mtryparam_arr[s-s_min, :, :] = mtryparams
 
             del df_mtry
 
@@ -1300,7 +1300,7 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                 mtrxparam_arr[:s-s_min, t-start_year, :] = \
                     np.tile(mtrxparams.reshape((1, numparams)),
                             (s-s_min, 1))
-                mtryparam_arr[:s-s_min, t-start_year, :] = \
+                mtryparam_arr[:s-s_min, :, :] = \
                     np.tile(mtryparams.reshape((1, numparams)),
                             (s-s_min, 1))
 
@@ -1339,7 +1339,7 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                 tvals = np.linspace(0, 1, NoData_cnt+2)
                 x0_etr = np.tile(
                     etrparam_arr[s-NoData_cnt-s_min-1,
-                                 t-start_year, :].reshape((1, numparams)),
+                                 :, :].reshape((1, numparams)),
                     (NoData_cnt, 1))
                 x1_etr = np.tile(etrparams.reshape((1, numparams)),
                                  (NoData_cnt, 1))
@@ -1347,10 +1347,10 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                     (x0_etr + tvals[1:-1].reshape((NoData_cnt, 1)) *
                      (x1_etr - x0_etr))
                 etrparam_arr[s-NoData_cnt-min_age:s-min_age,
-                             t-start_year, :] = lin_int_etr
+                             :, :] = lin_int_etr
                 x0_mtrx = np.tile(
                     mtrxparam_arr[s-NoData_cnt-s_min-1,
-                                  t-start_year, :].reshape((1, numparams)),
+                                  :, :].reshape((1, numparams)),
                     (NoData_cnt, 1))
                 x1_mtrx = np.tile(
                     mtrxparams.reshape((1, numparams)),
@@ -1359,10 +1359,10 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                     (x0_mtrx + tvals[1:-1].reshape((NoData_cnt, 1)) *
                      (x1_mtrx - x0_mtrx))
                 mtrxparam_arr[s-NoData_cnt-min_age:s-min_age,
-                              t-start_year, :] = lin_int_mtrx
+                              :, :] = lin_int_mtrx
                 x0_mtry = np.tile(
                     mtryparam_arr[s-NoData_cnt-s_min-1,
-                                  t-start_year, :].reshape((1, numparams)),
+                                  :, :].reshape((1, numparams)),
                     (NoData_cnt, 1))
                 x1_mtry = np.tile(
                     mtryparams.reshape((1, numparams)),
@@ -1371,7 +1371,7 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                     (x0_mtry + tvals[1:-1].reshape((NoData_cnt, 1)) *
                      (x1_mtry - x0_mtry))
                 mtryparam_arr[s-NoData_cnt-min_age:s-min_age,
-                              t-start_year, :] = lin_int_mtry
+                              :, :] = lin_int_mtry
 
             NoData_cnt == 0
 
@@ -1384,23 +1384,20 @@ def tax_func_loop(t, micro_data, start_year, s_min, s_max, age_specific,
                 '''
                 message = "Fill in all old tax functions."
                 print(message)
-                etrparam_arr[s-s_min+1:, t-start_year, :] = \
+                etrparam_arr[s-s_min+1:, :, :] = \
                     np.tile(etrparams.reshape((1, numparams)),
                             (s_max-max_age, 1))
-                mtrxparam_arr[s-s_min+1:, t-start_year, :] = \
+                mtrxparam_arr[s-s_min+1:, :, :] = \
                     np.tile(mtrxparams.reshape((1, numparams)),
                             (s_max-max_age, 1))
-                mtryparam_arr[s-s_min+1:, t-start_year, :] = \
+                mtryparam_arr[s-s_min+1:, :, :] = \
                     np.tile(mtryparams.reshape((1, numparams)),
                             (s_max-max_age, 1))
 
-    return (TotPop_yr[t-start_year], PopPct_age[:, t-start_year],
-            AvgInc[t-start_year], AvgETR[t-start_year], AvgMTRx[t-start_year],
-            AvgMTRy[t-start_year], etrparam_arr[:, t-start_year, :],
-            etr_wsumsq_arr[:, t-start_year], etr_obs_arr[:, t-start_year],
-            mtrxparam_arr[:, t-start_year, :], mtrx_wsumsq_arr[:, t-start_year],
-            mtrx_obs_arr[:, t-start_year], mtryparam_arr[:, t-start_year, :],
-            mtry_wsumsq_arr[:, t-start_year], mtry_obs_arr[:, t-start_year])
+    return (TotPop_yr, PopPct_age[:], AvgInc, AvgETR, AvgMTRx,AvgMTRy,
+            etrparam_arr[:],etr_wsumsq_arr[:], etr_obs_arr[:],mtrxparam_arr[:],
+            mtrx_wsumsq_arr[:],mtrx_obs_arr[:], mtryparam_arr[:],
+            mtry_wsumsq_arr[:], mtry_obs_arr[:])
 
 
 def tax_func_estimate(tpers, S, starting_age, ending_age,

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -254,12 +254,7 @@ def plot_txfunc_v_data(tx_params, data, params):  # This isn't in use yet
             fullpath = os.path.join(output_dir, filename)
             fig.savefig(fullpath, bbox_inches='tight')
 
-        if show_plots:
-            plt.show()
-
-        plt.close()
-
-    if plot_trunc:
+    else:
         # Make comparison plot with truncated income domains
         data_trnc = data[(data['Total labor income'] > 5) &
                          (data['Total labor income'] < 800000) &
@@ -308,8 +303,7 @@ def plot_txfunc_v_data(tx_params, data, params):  # This isn't in use yet
             plt.show()
 
         plt.close()
-
-
+   
 def get_tax_rates(params, X, Y, wgts, tax_func_type, rate_type,
                   for_estimation=True):
     X2 = X ** 2


### PR DESCRIPTION
This pull request addresses some of the issues raised in issue \#468.

1. Replaces `beg_yr `with `start_year` for consistency.

2. Replaces `BW` with `tpers` for consistency.

3. In the function `tax_func_loop`

4. Edits `plot_txfunc_v_data()` to only use `plot_full` boolean.

