### PR TITLE
fFx error in index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ OG-USA
 ==============
 
 OG-USA is a general equilibrium overlapping generations model of the United
-States. Open CGE is written in Python, an interpreted language that can execute
+States. OG-USA is written in Python, an interpreted language that can execute
 on Windows, Mac, or Linux.
 
 This documentation is about **developing** OG-USA.


### PR DESCRIPTION
@jdebacker 

This fixes a small error in `index.rst`. 

I think it should say "OG-USA" not "Open CGE".