### PR TITLE
Clean up creation of initial time paths

### DIFF
--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -542,8 +542,8 @@ def run_TPI(p, client=None):
                                   factor, trmat[:p.T, :, :], theta, 0,
                                   None, False, 'TPI', p.e,
                                   etr_params_4D, p)
-        r_hh_path = utils.to_timepath_shape(r_hh, p)
-        wpath = utils.to_timepath_shape(w, p)
+        r_hh_path = utils.to_timepath_shape(r_hh)
+        wpath = utils.to_timepath_shape(w)
         c_mat = household.get_cons(r_hh_path[:p.T, :, :], wpath[:p.T, :, :],
                                    bmat_s, bmat_splus1,
                                    n_mat[:p.T, :, :], bqmat[:p.T, :, :],

--- a/ogusa/TPI.py
+++ b/ogusa/TPI.py
@@ -402,23 +402,15 @@ def run_TPI(p, client=None):
 
     # Initialize guesses at time paths
     # Make array of initial guesses for labor supply and savings
-    domain = np.linspace(0, p.T, p.T)
-    domain2 = np.tile(domain.reshape(p.T, 1, 1), (1, p.S, p.J))
-    ending_b = ss_vars['bssmat_splus1']
-    guesses_b = (-1 / (domain2 + 1)) * (ending_b - initial_b) + ending_b
-    ending_b_tail = np.tile(ending_b.reshape(1, p.S, p.J), (p.S, 1, 1))
-    guesses_b = np.append(guesses_b, ending_b_tail, axis=0)
-
-    domain3 = np.tile(np.linspace(0, 1, p.T).reshape(p.T, 1, 1),
-                      (1, p.S, p.J))
-    guesses_n = domain3 * (ss_vars['nssmat'] - initial_n) + initial_n
-    ending_n_tail = np.tile(ss_vars['nssmat'].reshape(1, p.S, p.J),
-                            (p.S, 1, 1))
-    guesses_n = np.append(guesses_n, ending_n_tail, axis=0)
+    guesses_b = utils.get_initial_path(
+        initial_b, ss_vars['bssmat_splus1'], p, 'ratio')
+    guesses_n = utils.get_initial_path(
+        initial_n, ss_vars['nssmat'], p, 'ratio')
     b_mat = guesses_b
     n_mat = guesses_n
     ind = np.arange(p.S)
 
+    # Get path for aggregate savings and labor supply`
     L_init = np.ones((p.T + p.S,)) * ss_vars['Lss']
     B_init = np.ones((p.T + p.S,)) * ss_vars['Bss']
     L_init[:p.T] = aggr.get_L(n_mat[:p.T], p, 'TPI')

--- a/ogusa/aggregates.py
+++ b/ogusa/aggregates.py
@@ -289,8 +289,8 @@ def revenue(r, w, b, n, bq, c, Y, L, K, factor, theta, etr_params,
                     (T_I + T_P + T_BQ + T_W + T_C)).sum() +
                    business_revenue)
     elif method == 'TPI':
-        r_array = utils.to_timepath_shape(r, p)
-        w_array = utils.to_timepath_shape(w, p)
+        r_array = utils.to_timepath_shape(r)
+        w_array = utils.to_timepath_shape(w)
         I = r_array * b + w_array * n * p.e
         T_I = np.zeros_like(I)
         T_I = tax.ETR_income(r_array, w_array, b, n, factor, p.e,

--- a/ogusa/household.py
+++ b/ogusa/household.py
@@ -135,7 +135,7 @@ def get_bq(BQ, j, p, method):
             else:
                 len_T = BQ.shape[0]
                 bq = ((np.reshape(p.zeta, (1, p.S, p.J)) *
-                      utils.to_timepath_shape(BQ, p)) /
+                      utils.to_timepath_shape(BQ)) /
                       (p.lambdas.reshape((1, 1, p.J)) *
                        p.omega[:len_T, :].reshape((len_T, p.S, 1))))
     else:
@@ -192,7 +192,7 @@ def get_tr(TR, j, p, method):
         else:
             len_T = TR.shape[0]
             tr = ((p.eta[:len_T, :, :] *
-                   utils.to_timepath_shape(TR, p)) /
+                   utils.to_timepath_shape(TR)) /
                   (p.lambdas.reshape((1, 1, p.J)) *
                    p.omega[:len_T, :].reshape((len_T, p.S, 1))))
 
@@ -271,8 +271,8 @@ def FOC_savings(r, w, b, b_splus1, n, bq, factor, tr, theta, e, rho,
     else:
         chi_b = p.chi_b
         if method == 'TPI':
-            r = utils.to_timepath_shape(r, p)
-            w = utils.to_timepath_shape(w, p)
+            r = utils.to_timepath_shape(r)
+            w = utils.to_timepath_shape(w)
 
     taxes = tax.total_taxes(r, w, b, n, bq, factor, tr, theta, t, j,
                             False, method, e, etr_params, p)
@@ -350,9 +350,9 @@ def FOC_labor(r, w, b, b_splus1, n, bq, factor, tr, theta, chi_n, e,
             w = w.reshape(w.shape[0], 1)
             tau_payroll = tau_payroll.reshape(tau_payroll.shape[0], 1)
         elif b.ndim == 3:
-            r = utils.to_timepath_shape(r, p)
-            w = utils.to_timepath_shape(w, p)
-            tau_payroll = utils.to_timepath_shape(tau_payroll, p)
+            r = utils.to_timepath_shape(r)
+            w = utils.to_timepath_shape(w)
+            tau_payroll = utils.to_timepath_shape(tau_payroll)
 
     taxes = tax.total_taxes(r, w, b, n, bq, factor, tr, theta, t, j,
                             False, method, e, etr_params, p)

--- a/ogusa/tax.py
+++ b/ogusa/tax.py
@@ -369,8 +369,8 @@ def total_taxes(r, w, b, n, bq, factor, tr, theta, t, j, shift, method,
     else:
         lambdas = np.transpose(p.lambdas)
         if method == 'TPI':
-            r = utils.to_timepath_shape(r, p)
-            w = utils.to_timepath_shape(w, p)
+            r = utils.to_timepath_shape(r)
+            w = utils.to_timepath_shape(w)
 
     income = r * b + w * e * n
     T_I = ETR_income(r, w, b, n, factor, e, etr_params, p) * income

--- a/ogusa/tests/test_utils.py
+++ b/ogusa/tests/test_utils.py
@@ -17,6 +17,15 @@ def test_rate_conversion():
     assert(np.allclose(expected_rate, test_rate))
 
 
+def test_to_timepath_shape():
+    '''
+    Test of function that converts vector to time path conformable array
+    '''
+    in_array = np.ones(40)
+    test_array = utils.to_timepath_shape(in_array)
+    assert test_array.shape == (40, 1, 1)
+
+
 p = Specifications()
 p.T = 40
 p.S = 3

--- a/ogusa/tests/test_utils.py
+++ b/ogusa/tests/test_utils.py
@@ -1,11 +1,12 @@
 import pytest
 from ogusa import utils
 import numpy as np
+from ogusa.parameters import Specifications
 
 
 def test_rate_conversion():
     '''
-    test of utils.rate_conversion
+    Test of utils.rate_conversion
     '''
     expected_rate = 0.3
     annual_rate = 0.3
@@ -14,3 +15,67 @@ def test_rate_conversion():
     s = 60
     test_rate = utils.rate_conversion(annual_rate, start_age, end_age, s)
     assert(np.allclose(expected_rate, test_rate))
+
+
+p = Specifications()
+p.T = 40
+p.S = 3
+p.J = 1
+# new_param_values = {
+#     'T': 40,
+#     'S': 3,
+#     'J': 1
+# }
+# # update parameters instance with new values for test
+# p.update_specifications(new_param_values)
+x1 = np.ones((p.S, p.J)) * 0.4
+xT = np.ones((p.S, p.J)) * 5.0
+expected1 = np.tile(np.array([
+    0.4, 0.51794872, 0.63589744, 0.75384615, 0.87179487, 0.98974359,
+    1.10769231, 1.22564103, 1.34358974, 1.46153846, 1.57948718,
+    1.6974359, 1.81538462, 1.93333333, 2.05128205, 2.16923077,
+    2.28717949, 2.40512821, 2.52307692, 2.64102564, 2.75897436,
+    2.87692308, 2.99487179, 3.11282051, 3.23076923, 3.34871795,
+    3.46666667, 3.58461538, 3.7025641, 3.82051282, 3.93846154,
+    4.05641026, 4.17435897, 4.29230769, 4.41025641, 4.52820513,
+    4.64615385, 4.76410256, 4.88205128, 5., 5.0, 5.0, 5.0]
+                             ).reshape(p.T + p.S, 1, 1), (1, p.S, p.J))
+expected2 = np.tile(np.array([
+    0.4, 0.63287311, 0.85969757, 1.08047337, 1.29520053, 1.50387903,
+    1.70650888, 1.90309007, 2.09362262, 2.27810651, 2.45654175,
+    2.62892834, 2.79526627, 2.95555556, 3.10979619, 3.25798817,
+    3.40013149, 3.53622617, 3.66627219, 3.79026956, 3.90821828,
+    4.02011834, 4.12596976, 4.22577252, 4.31952663, 4.40723208,
+    4.48888889, 4.56449704, 4.63405654, 4.69756739, 4.75502959,
+    4.80644313, 4.85180802, 4.89112426, 4.92439185, 4.95161078,
+    4.97278107, 4.9879027,  4.99697567, 5., 5., 5., 5.]
+                             ).reshape(p.T + p.S, 1, 1), (1, p.S, p.J))
+expected3 = np.tile(np.array([
+    0.4, 2.72911392, 3.49243697, 3.87169811, 4.09849246, 4.24937238,
+    4.35698925, 4.43761755, 4.50027855, 4.55037594, 4.59134396,
+    4.62546973, 4.65433526, 4.67906977, 4.70050083, 4.71924883,
+    4.73578792, 4.75048679, 4.76363636, 4.77546934, 4.78617402,
+    4.79590444, 4.80478781, 4.81293014, 4.82042042, 4.82733397,
+    4.83373494, 4.83967828, 4.84521139, 4.85037531, 4.85520581,
+    4.85973417, 4.86398787, 4.86799117, 4.87176555, 4.87533009,
+    4.87870183, 4.88189598, 4.88492623, 4.88780488, 5., 5., 5.]
+                             ).reshape(p.T + p.S, 1, 1), (1, p.S, p.J))
+expected4 = np.ones((p.T + p.S, p.S, p.J)) * xT
+
+
+@pytest.mark.parametrize(
+    'x1,xT,p,shape,expected', [
+        (x1, xT, p, 'linear', expected1),
+        (x1, xT, p, 'quadratic', expected2),
+        (x1, xT, p, 'ratio', expected3),
+        (xT, xT, p, 'linear', expected4),
+        (xT, xT, p, 'quadratic', expected4),
+        (xT, xT, p, 'ratio', expected4)],
+    ids=['linear', 'quadratic', 'ratio', 'linear - trivial',
+         'quadratic - trivial', 'ratio- trivial'])
+def test_get_initial_path(x1, xT, p, shape, expected):
+    '''
+    Test of utils.get_inital_path function
+    '''
+    test_path = utils.get_initial_path(x1, xT, p, shape)
+    assert np.allclose(test_path, expected)

--- a/ogusa/utils.py
+++ b/ogusa/utils.py
@@ -303,14 +303,13 @@ def dict_compare(fname1, pkl1, fname2, pkl2, tol, verbose=False,
     return check
 
 
-def to_timepath_shape(some_array, p):
+def to_timepath_shape(some_array):
     '''
     This function takes an vector of length T and tiles it to fill a
     Tx1x1 array for time path computations.
 
     Args:
         some_array (Numpy array): array to reshape
-        p (OG-USA Specifcations object): model parameters
 
     Returns:
         tp_array (Numpy  array): reshaped array


### PR DESCRIPTION
This PR makes use a function in `utils.py` to create a time path for variables of a specific shape.  It adds tests of this function.  

Some clean up and tests of `utils.to_timepath_shape()` were also added.