### PR TITLE
Added pip as a dependency in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
 - "taxcalc>=2.4.2"
 - "dask>=0.20.0"
 - "paramtools>=0.7.1"
+- pip
 - pytest
 - pytest-pep8
 - pytest-xdist


### PR DESCRIPTION
This PR adds `pip` as a dependency in `environment.yml`. This seems to be a push by `conda` as not having it included generates the following warning:
```
Warning: you have pip-installed dependencies in your environment file,
but you do not list pip itself as one of your conda dependencies.  Conda
may not use the correct pip to install your packages, and they may end
up in the wrong place.  Please add an explicit pip dependency.  I'm
adding one for you, but still nagging you.
```
@jdebacker 