### PR TITLE
Tax plots

### DIFF
--- a/ogusa/parameter_plots.py
+++ b/ogusa/parameter_plots.py
@@ -572,6 +572,19 @@ def txfunc_graph(s, t, df, X, Y, txrates, rate_type, tax_func_type,
     the data.
 
     Args:
+        s (int): age of individual, >= 21
+        t (int): year of analysis, >= 2016
+        df (Pandas DataFrame): 11 variables with N observations of tax
+            rates
+        X (Pandas DataSeries): labor income
+        Y (Pandas DataSeries): capital income
+        Y (Pandas DataSeries): tax rates from the data
+        rate_type (str): type of tax rate: mtrx, mtry, etr
+        tax_func_type (str): functional form of tax functions
+        get_tax_rates (function): function to generate tax rates given
+            parameters
+        params_to_plot (Numpy Array): tax function parameters
+        output_dir (str): output directory for saving plot files
 
     Returns:
         None
@@ -651,3 +664,38 @@ def txfunc_graph(s, t, df, X, Y, txrates, rate_type, tax_func_type,
     plt.close()
 
     del df_trnc_gph
+
+
+def txfunc_sse_plot(age_vec, sse_mat, start_year, varstr, output_dir,
+                    round):
+    '''
+    Plot sum of squared errors of tax functions over age for each year
+    of budget window.
+
+    Args:
+        age_vec (numpy array): vector of ages, length S
+        sse_mat (Numpy array): SSE for each estimated tax function,
+            size is SxBW
+        start_year (int): first year of budget window
+        varstr (str): name of tax function being evaluated
+        output_dir (str): path to save graph to
+        round (int): which round of sweeping for outliers (0, 1, or 2)
+
+    Returns:
+        None
+
+    '''
+    fig, ax = plt.subplots()
+    BW = sse_mat.shape[1]
+    for y in range(BW):
+        plt.plot(age_vec, sse_mat[:, y], label=str(start_year + y))
+    plt.legend(loc='upper left')
+    titletext = ("Sum of Squared Errors by age and Tax Year" +
+                 " minus outliers (Round " + str(round) + "): " + varstr)
+    plt.title(titletext)
+    plt.xlabel(r'age $s$')
+    plt.ylabel(r'SSE')
+    graphname = "SSE_" + varstr + "_Round" + str(round)
+    output_path = os.path.join(output_dir, graphname)
+    plt.savefig(output_path, bbox_inches='tight')
+    plt.close()

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -16,8 +16,6 @@ import scipy.optimize as opt
 from dask import delayed, compute
 import dask.multiprocessing
 import pickle
-import matplotlib.pyplot as plt
-from matplotlib.ticker import MultipleLocator
 from ogusa import get_micro_data
 from ogusa.utils import DEFAULT_START_YEAR
 import ogusa.parameter_plots as pp

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -695,100 +695,6 @@ def txfunc_est(df, s, t, rate_type, tax_func_type, numparams,
         pp.txfunc_graph(s, t, df, X, Y, txrates, rate_type,
                         tax_func_type, get_tax_rates, params_to_plot,
                         output_dir)
-        # '''
-        # ----------------------------------------------------------------
-        # cmap1       = color map object for matplotlib 3D plots
-        # tx_label    = string, text representing type of tax rate
-        # gridpts     = scalar > 2, number of grid points in X and Y
-        #               dimensions
-        # X_vec       = (gridpts,) vector, discretized log support of X
-        # Y_vec       = (gridpts,) vector, discretized log support of Y
-        # X_grid      = (gridpts, gridpts) matrix, ?
-        # Y_grid      = (gridpts, gridpts) matrix, ?
-        # txrate_grid = (gridpts, gridpts) matrix, ?
-        # filename    = string, name of plot to be saved
-        # fullpath    = string, full path name of file to be saved
-        # df_trnc_gph = (Nb, 11) DataFrame, truncated data for plotting
-        # X_gph       = (Nb,) Series, truncated labor income data
-        # Y_gph       = (Nb,) Series, truncated capital income data
-        # txrates_gph = (Nb,) Series, truncated tax rate (ETR, MTRx, or
-        #               MTRy) data
-        # ----------------------------------------------------------------
-        # '''
-        # cmap1 = matplotlib.cm.get_cmap('summer')
-        #
-        # # Make comparison plot with full income domains
-        # fig = plt.figure()
-        # ax = fig.add_subplot(111, projection='3d')
-        # ax.scatter(X, Y, txrates, c='r', marker='o')
-        # ax.set_xlabel('Total Labor Income')
-        # ax.set_ylabel('Total Capital Income')
-        # if rate_type == 'etr':
-        #     tx_label = 'ETR'
-        # elif rate_type == 'mtrx':
-        #     tx_label = 'MTRx'
-        # elif rate_type == 'mtry':
-        #     tx_label = 'MTRy'
-        # ax.set_zlabel(tx_label)
-        # plt.title(tx_label + ' vs. Predicted ' + tx_label + ': Age=' +
-        #           str(s) + ', Year=' + str(t))
-        #
-        # gridpts = 50
-        # X_vec = np.exp(np.linspace(np.log(5), np.log(X.max()), gridpts))
-        # Y_vec = np.exp(np.linspace(np.log(5), np.log(Y.max()), gridpts))
-        # X_grid, Y_grid = np.meshgrid(X_vec, Y_vec)
-        # txrate_grid = get_tax_rates(params_to_plot, X_grid, Y_grid, None,
-        #                             tax_func_type, rate_type,
-        #                             for_estimation=False)
-        # ax.plot_surface(X_grid, Y_grid, txrate_grid, cmap=cmap1,
-        #                 linewidth=0)
-        # filename = (tx_label + '_age_' + str(s) + '_Year_' + str(t) +
-        #             '_vsPred.png')
-        # fullpath = os.path.join(output_dir, filename)
-        # fig.savefig(fullpath, bbox_inches='tight')
-        # plt.close()
-        #
-        # # Make comparison plot with truncated income domains
-        # df_trnc_gph = df[(df['total_labinc'] > 5) &
-        #                  (df['total_labinc'] < 800000) &
-        #                  (df['total_capinc'] > 5) &
-        #                  (df['total_capinc'] < 800000)]
-        # X_gph = df_trnc_gph['total_labinc']
-        # Y_gph = df_trnc_gph['total_capinc']
-        # if rate_type == 'etr':
-        #     txrates_gph = df_trnc_gph['etr']
-        # elif rate_type == 'mtrx':
-        #     txrates_gph = df_trnc_gph['mtr_labinc']
-        # elif rate_type == 'mtry':
-        #     txrates_gph = df_trnc_gph['mtr_capinc']
-        #
-        # fig = plt.figure()
-        # ax = fig.add_subplot(111, projection='3d')
-        # ax.scatter(X_gph, Y_gph, txrates_gph, c='r', marker='o')
-        # ax.set_xlabel('Total Labor Income')
-        # ax.set_ylabel('Total Capital Income')
-        # ax.set_zlabel(tx_label)
-        # plt.title('Truncated ' + tx_label + ', Lab. Inc., and Cap. ' +
-        #           'Inc., Age=' + str(s) + ', Year=' + str(t))
-        #
-        # gridpts = 50
-        # X_vec = np.exp(np.linspace(np.log(5), np.log(X_gph.max()),
-        #                            gridpts))
-        # Y_vec = np.exp(np.linspace(np.log(5), np.log(Y_gph.max()),
-        #                            gridpts))
-        # X_grid, Y_grid = np.meshgrid(X_vec, Y_vec)
-        # txrate_grid = get_tax_rates(
-        #     params_to_plot, X_grid, Y_grid, None, tax_func_type,
-        #     rate_type, for_estimation=False)
-        # ax.plot_surface(X_grid, Y_grid, txrate_grid, cmap=cmap1,
-        #                 linewidth=0)
-        # filename = (tx_label + 'trunc_age_' + str(s) + '_Year_' +
-        #             str(t) + '_vsPred.png')
-        # fullpath = os.path.join(output_dir, filename)
-        # fig.savefig(fullpath, bbox_inches='tight')
-        # plt.close()
-        #
-        # del df_trnc_gph
 
     # Garbage collection
     del df, txrates
@@ -1260,7 +1166,7 @@ def tax_func_estimate(BW, S, starting_age, ending_age,
     # --------------------------------------------------------------------
     # '''
     start_time = time.time()
-    output_dir = os.path.join(cCUR_PATH, 'OUTPUT', 'TaxFunctions')
+    output_dir = os.path.join(CUR_PATH, 'OUTPUT', 'TaxFunctions')
     if not os.access(output_dir, os.F_OK):
         os.makedirs(output_dir)
 

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -311,37 +311,10 @@ def find_outliers(sse_mat, age_vec, se_mult, start_year, varstr,
     sse_big_mat = sse_mat > thresh
     print(varstr, ": ", str(sse_big_mat.sum()),
           " observations tagged as outliers.")
+    output_dir = os.path.join(CUR_PATH, 'OUTPUT', 'TaxFunctions')
     if graph:
-        # Plot sum of squared errors of tax functions over age for each
-        # year of budget window
-        fig, ax = plt.subplots()
-        plt.plot(age_vec, sse_mat[:, 0], label=str(start_year))
-        plt.plot(age_vec, sse_mat[:, 1], label=str(start_year + 1))
-        plt.plot(age_vec, sse_mat[:, 2], label=str(start_year + 2))
-        plt.plot(age_vec, sse_mat[:, 3], label=str(start_year + 3))
-        plt.plot(age_vec, sse_mat[:, 4], label=str(start_year + 4))
-        plt.plot(age_vec, sse_mat[:, 5], label=str(start_year + 5))
-        plt.plot(age_vec, sse_mat[:, 6], label=str(start_year + 6))
-        plt.plot(age_vec, sse_mat[:, 7], label=str(start_year + 7))
-        plt.plot(age_vec, sse_mat[:, 8], label=str(start_year + 8))
-        plt.plot(age_vec, sse_mat[:, 9], label=str(start_year + 9))
-        # for the minor ticks, use no labels; default NullFormatter
-        minorLocator = MultipleLocator(1)
-        ax.xaxis.set_minor_locator(minorLocator)
-        plt.grid(b=True, which='major', color='0.65', linestyle='-')
-        plt.legend(loc='upper left')
-        titletext = "Sum of Squared Errors by age and Tax Year: " + varstr
-        plt.title(titletext)
-        plt.xlabel(r'age $s$')
-        plt.ylabel(r'SSE')
-        # Create directory if OUTPUT directory does not already exist
-        output_dir = os.path.join(CUR_PATH, 'OUTPUT', 'TaxFunctions')
-        if not os.access(output_dir, os.F_OK):
-            os.makedirs(output_dir)
-        graphname = "SSE_" + varstr
-        output_path = os.path.join(output_dir, graphname)
-        plt.savefig(output_path)
-        # plt.show()
+        pp.txfunc_sse_plot(age_vec, sse_mat, start_year, varstr,
+                           output_dir, 0)
     if sse_big_mat.sum() > 0:
         # Mark the outliers from the first sweep above. Then mark the
         # new outliers in a second sweep
@@ -354,84 +327,15 @@ def find_outliers(sse_mat, age_vec, se_mult, start_year, varstr,
               str(sse_big_mat.sum()),
               " observations tagged as outliers (cumulative).")
         if graph:
-            # Plot sum of squared errors of tax functions over age for
-            # each year of budget window
-            fig, ax = plt.subplots()
-            plt.plot(age_vec, sse_mat_new[:, 0], label=str(start_year))
-            plt.plot(age_vec, sse_mat_new[:, 1],
-                     label=str(start_year + 1))
-            plt.plot(age_vec, sse_mat_new[:, 2],
-                     label=str(start_year + 2))
-            plt.plot(age_vec, sse_mat_new[:, 3],
-                     label=str(start_year + 3))
-            plt.plot(age_vec, sse_mat_new[:, 4],
-                     label=str(start_year + 4))
-            plt.plot(age_vec, sse_mat_new[:, 5],
-                     label=str(start_year + 5))
-            plt.plot(age_vec, sse_mat_new[:, 6],
-                     label=str(start_year + 6))
-            plt.plot(age_vec, sse_mat_new[:, 7],
-                     label=str(start_year + 7))
-            plt.plot(age_vec, sse_mat_new[:, 8],
-                     label=str(start_year + 8))
-            plt.plot(age_vec, sse_mat_new[:, 9],
-                     label=str(start_year + 9))
-            # for the minor ticks, use no labels; default NullFormatter
-            minorLocator = MultipleLocator(1)
-            ax.xaxis.set_minor_locator(minorLocator)
-            plt.grid(b=True, which='major', color='0.65', linestyle='-')
-            plt.legend(loc='upper left')
-            titletext = ("Sum of Squared Errors by age and Tax Year" +
-                         " minus outliers (round 1): " + varstr)
-            plt.title(titletext)
-            plt.xlabel(r'age $s$')
-            plt.ylabel(r'SSE')
-            graphname = "SSE_" + varstr + "_NoOut1"
-            output_path = os.path.join(output_dir, graphname)
-            plt.savefig(output_path)
-            # plt.show()
+            pp.txfunc_sse_plot(age_vec, sse_mat_new, start_year, varstr,
+                               output_dir, 1)
         if (sse_mat_new > thresh2).sum() > 0:
             # Mark the outliers from the second sweep above
             sse_mat_new2 = sse_mat_new.copy()
             sse_mat_new2[sse_big_mat] = np.nan
             if graph:
-                # Plot sum of squared errors of tax functions over age
-                # for each year of budget window
-                fig, ax = plt.subplots()
-                plt.plot(age_vec, sse_mat_new2[:, 0], label=str(start_year))
-                plt.plot(age_vec, sse_mat_new2[:, 1],
-                         label=str(start_year + 1))
-                plt.plot(age_vec, sse_mat_new2[:, 2],
-                         label=str(start_year + 2))
-                plt.plot(age_vec, sse_mat_new2[:, 3],
-                         label=str(start_year + 3))
-                plt.plot(age_vec, sse_mat_new2[:, 4],
-                         label=str(start_year + 4))
-                plt.plot(age_vec, sse_mat_new2[:, 5],
-                         label=str(start_year + 5))
-                plt.plot(age_vec, sse_mat_new2[:, 6],
-                         label=str(start_year + 6))
-                plt.plot(age_vec, sse_mat_new2[:, 7],
-                         label=str(start_year + 7))
-                plt.plot(age_vec, sse_mat_new2[:, 8],
-                         label=str(start_year + 8))
-                plt.plot(age_vec, sse_mat_new2[:, 9],
-                         label=str(start_year + 9))
-                # for the minor ticks, use no labels; default NullFormatter
-                minorLocator = MultipleLocator(1)
-                ax.xaxis.set_minor_locator(minorLocator)
-                plt.grid(b=True, which='major', color='0.65',
-                         linestyle='-')
-                plt.legend(loc='upper left')
-                titletext = ("Sum of Squared Errors by age and Tax Year"
-                             + " minus outliers (round 2): " + varstr)
-                plt.title(titletext)
-                plt.xlabel(r'age $s$')
-                plt.ylabel(r'SSE')
-                graphname = "SSE_" + varstr + "_NoOut2"
-                output_path = os.path.join(output_dir, graphname)
-                plt.savefig(output_path)
-                # plt.show()
+                pp.txfunc_sse_plot(age_vec, sse_mat_new2, start_year,
+                                   varstr, output_dir, 2)
 
     return sse_big_mat
 
@@ -1239,7 +1143,8 @@ def tax_func_estimate(BW, S, starting_age, ending_age,
         age_sup = np.linspace(s_min, s_max, s_max-s_min+1)
         se_mult = 3.5
         etr_sse_big = find_outliers(etr_wsumsq_arr / etr_obs_arr,
-                                    age_sup, se_mult, start_year, "ETR")
+                                    age_sup, se_mult, start_year, "ETR",
+                                    graph=graph_est)
         if etr_sse_big.sum() > 0:
             etrparam_arr_adj = replace_outliers(etrparam_arr,
                                                 etr_sse_big)
@@ -1247,7 +1152,8 @@ def tax_func_estimate(BW, S, starting_age, ending_age,
             etrparam_arr_adj = etrparam_arr
 
         mtrx_sse_big = find_outliers(mtrx_wsumsq_arr / mtrx_obs_arr,
-                                     age_sup, se_mult, start_year, "MTRx")
+                                     age_sup, se_mult, start_year,
+                                     "MTRx", graph=graph_est)
         if mtrx_sse_big.sum() > 0:
             mtrxparam_arr_adj = replace_outliers(mtrxparam_arr,
                                                  mtrx_sse_big)
@@ -1255,7 +1161,8 @@ def tax_func_estimate(BW, S, starting_age, ending_age,
             mtrxparam_arr_adj = mtrxparam_arr
 
         mtry_sse_big = find_outliers(mtry_wsumsq_arr / mtry_obs_arr,
-                                     age_sup, se_mult, start_year, "MTRy")
+                                     age_sup, se_mult, start_year,
+                                     "MTRy", graph=graph_est)
         if mtry_sse_big.sum() > 0:
             mtryparam_arr_adj = replace_outliers(mtryparam_arr,
                                                  mtry_sse_big)

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -16,14 +16,13 @@ import scipy.optimize as opt
 from dask import delayed, compute
 import dask.multiprocessing
 import pickle
-import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib.ticker import MultipleLocator
 from ogusa import get_micro_data
 from ogusa.utils import DEFAULT_START_YEAR
 import ogusa.parameter_plots as pp
 
-TAX_ESTIMATE_PATH = os.environ.get("TAX_ESTIMATE_PATH", ".")
+CUR_PATH = os.path.split(os.path.abspath(__file__))[0]
 MIN_OBS = 240  # 240 is 8 parameters to estimate X 30 obs per parameter
 MIN_ETR = -0.15
 MAX_ETR = 0.65
@@ -336,8 +335,7 @@ def find_outliers(sse_mat, age_vec, se_mult, start_year, varstr,
         plt.xlabel(r'age $s$')
         plt.ylabel(r'SSE')
         # Create directory if OUTPUT directory does not already exist
-        cur_path = os.path.split(os.path.abspath(__file__))[0]
-        output_dir = os.path.join(cur_path, 'OUTPUT', 'TaxFunctions')
+        output_dir = os.path.join(CUR_PATH, 'OUTPUT', 'TaxFunctions')
         if not os.access(output_dir, os.F_OK):
             os.makedirs(output_dir)
         graphname = "SSE_" + varstr
@@ -1262,8 +1260,7 @@ def tax_func_estimate(BW, S, starting_age, ending_age,
     # --------------------------------------------------------------------
     # '''
     start_time = time.time()
-    cur_path = os.path.split(os.path.abspath(__file__))[0]
-    output_dir = os.path.join(cur_path, 'OUTPUT', 'TaxFunctions')
+    output_dir = os.path.join(cCUR_PATH, 'OUTPUT', 'TaxFunctions')
     if not os.access(output_dir, os.F_OK):
         os.makedirs(output_dir)
 

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -39,127 +39,6 @@ Define Functions
 '''
 
 
-# def plot_txfunc_v_data(tx_params, data, params):  # This isn't in use yet
-#     '''
-#     This function plots a single estimated tax function against its
-#     corresponding data
-#
-#     Args:
-#         tx_params (Numpy array):
-#         data (Pandas DataFrame): 11 variables with N observations of tax
-#             rates
-#         params (tuple): containts (s, t, rate_type, plot_full,
-#             show_plots, save_plots, output_dir)
-#         s (int): age of individual, >= 21
-#         t (int): year of analysis, >= 2016
-#         tax_func_type (str): functional form of tax functions
-#         rate_type (str): type of tax rate: mtrx, mtry, etr
-#         plot_full (bool): whether to plot all data points or a truncated
-#             set of data
-#         show_plots (bool): whether to show plots
-#         save_plots (bool): whether to save plots
-#         output_dir (str): output directory for saving plot files
-#
-#     Returns:
-#         None
-#
-#     '''
-#     X_data = data['total_labinc']
-#     Y_data = data['total_capinc']
-#     (s, t, tax_func_type, rate_type, plot_full, show_plots,
-#      save_plots, output_dir) = params
-#
-#     cmap1 = matplotlib.cm.get_cmap('summer')
-#
-#     if plot_full:
-#         if rate_type == 'etr':
-#             txrate_data = data['etr']
-#             tx_label = 'etr'
-#         elif rate_type == 'mtrx':
-#             txrate_data = data['mtr_labinc']
-#             tx_label = 'MTRx'
-#         elif rate_type == 'mtry':
-#             txrate_data = data['mtr_capinc']
-#             tx_label = 'MTRy'
-#         # Make comparison plot with full income domains
-#         fig = plt.figure()
-#         ax = fig.add_subplot(111, projection='3d')
-#         ax.scatter(X_data, Y_data, txrate_data, c='r', marker='o')
-#         ax.set_xlabel('Total Labor Income')
-#         ax.set_ylabel('Total Capital Income')
-#         ax.set_zlabel(tx_label)
-#         plt.title(tx_label + ' vs. Predicted ' + tx_label + ': Age=' +
-#                   str(s) + ', Year=' + str(t))
-#
-#         gridpts = 50
-#         X_vec = np.exp(np.linspace(np.log(1), np.log(X_data.max()),
-#                                    gridpts))
-#         Y_vec = np.exp(np.linspace(np.log(1), np.log(Y_data.max()),
-#                                    gridpts))
-#         X_grid, Y_grid = np.meshgrid(X_vec, Y_vec)
-#         txrate_grid = get_tax_rates(
-#             tx_params, X_grid, Y_grid, None, tax_func_type, rate_type,
-#             for_estimation=False)
-#         ax.plot_surface(X_grid, Y_grid, txrate_grid, cmap=cmap1,
-#                         linewidth=0)
-#
-#         if save_plots:
-#             filename = (tx_label + '_age_' + str(s) + '_Year_' + str(t)
-#                         + '_vsPred.png')
-#             fullpath = os.path.join(output_dir, filename)
-#             fig.savefig(fullpath, bbox_inches='tight')
-#
-#     else:
-#         # Make comparison plot with truncated income domains
-#         data_trnc = data[(data['total_labinc'] > MIN_INC_GRAPH) &
-#                          (data['total_labinc'] < MAX_INC_GRAPH) &
-#                          (data['total_capinc'] > MIN_INC_GRAPH) &
-#                          (data['total_capinc'] < MAX_INC_GRAPH)]
-#         X_trnc = data_trnc['total_labinc']
-#         Y_trnc = data_trnc['total_capinc']
-#         if rate_type == 'etr':
-#             txrates_trnc = data_trnc['etr']
-#             tx_label = 'etr'
-#         elif rate_type == 'mtrx':
-#             txrates_trnc = data_trnc['mtr_labinc']
-#             tx_label = 'MTRx'
-#         elif rate_type == 'mtry':
-#             txrates_trnc = data_trnc['mtr_capinc']
-#             tx_label = 'MTRy'
-#
-#         fig = plt.figure()
-#         ax = fig.add_subplot(111, projection='3d')
-#         ax.scatter(X_trnc, Y_trnc, txrates_trnc, c='r', marker='o')
-#         ax.set_xlabel('Total Labor Income')
-#         ax.set_ylabel('Total Capital Income')
-#         ax.set_zlabel(tx_label)
-#         plt.title('Truncated ' + tx_label + ', Lab. Inc., and Cap. ' +
-#                   'Inc., Age=' + str(s) + ', Year=' + str(t))
-#
-#         gridpts = 50
-#         X_vec = np.exp(np.linspace(np.log(1), np.log(X_trnc.max()),
-#                                    gridpts))
-#         Y_vec = np.exp(np.linspace(np.log(1), np.log(Y_trnc.max()),
-#                                    gridpts))
-#         X_grid, Y_grid = np.meshgrid(X_vec, Y_vec)
-#         txrate_grid = get_tax_rates(
-#             tx_params, X_grid, Y_grid, None, tax_func_type, rate_type,
-#             for_estimation=False)
-#         ax.plot_surface(X_grid, Y_grid, txrate_grid, cmap=cmap1,
-#                         linewidth=0)
-#
-#         if save_plots:
-#             filename = (tx_label + 'trunc_age_' + str(s) + '_Year_' +
-#                         str(t) + '_vsPred.png')
-#             fullpath = os.path.join(output_dir, filename)
-#             fig.savefig(fullpath, bbox_inches='tight')
-#
-#         if show_plots:
-#             plt.show()
-#
-#         plt.close()
-
-
 def get_tax_rates(params, X, Y, wgts, tax_func_type, rate_type,
                   for_estimation=True):
     '''
@@ -296,9 +175,9 @@ def find_outliers(sse_mat, age_vec, se_mult, start_year, varstr,
         age_vec (numpy array): vector of ages, length S
         se_mult (scalar): multiple of standard deviations before
             consider estimate an outlier
-    start_year (int): first year of budget window
-    varstr (str): name of tax function being evaluated
-    graph (bool): whether to output graphs
+        start_year (int): first year of budget window
+        varstr (str): name of tax function being evaluated
+        graph (bool): whether to output graphs
 
     Returns:
         sse_big_mat (Numpy array): indicators of weither tax function


### PR DESCRIPTION
This PR moves the plotting of tax functions out of `txfunc.py` and into `parameter_plots.py`, in response to Issue #92.  

At some point, we should probably change how these functions are used.  Rather than being called within a tax function estimation run, it might be better if they could be called with data saved from the estimation, so that one could used these functions with any cached data (i.e., not have to run the estimation again to plot the tax functions with the data).  Or perhaps they could be structured in a way so as to handle both cases.

In any case this PR will not only move the location of the functions to make `txfunc.py` more clear.  It will not restructure them to work easily with cached data.