### PR TITLE
Add output tables rst file

### DIFF
--- a/docs/source/output_tables.rst
+++ b/docs/source/output_tables.rst
@@ -1,0 +1,15 @@
+.. _parameter_tables:
+
+OG-USA Output Table Building Functions
+=================================================
+
+**OG-USA Output Table Building Functions**
+
+ogusa.output_tables
+------------------------------------------
+
+.. currentmodule:: ogusa.output_tables
+
+.. automodule:: ogusa.output_tables
+  :members: macro_table, macro_table_SS, ineq_table, gini_table,
+    wealth_moments_table


### PR DESCRIPTION
The rst file for the Sphinx docs was missing for the `output_tables` module.