### PR TITLE
Sigma values

### DIFF
--- a/ogusa/default_parameters.json
+++ b/ogusa/default_parameters.json
@@ -213,8 +213,8 @@
         ],
         "validators": {
             "range": {
-                "min": 1.0,
-                "max": 3.5
+                "min": 1.3,
+                "max": 1.9
             }
         }
     },

--- a/ogusa/tests/test_user_inputs.py
+++ b/ogusa/tests/test_user_inputs.py
@@ -2,7 +2,7 @@ import pytest
 import os
 from ogusa.execute import runner
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
-PUF_PATH = os.path.join(CUR_PATH, '../puf.csv')
+PUF_PATH = os.path.join(CUR_PATH, '..', 'puf.csv')
 
 
 @pytest.mark.full_run
@@ -25,6 +25,20 @@ def test_gy(g_y_annual):
     input_dir = os.path.join(CUR_PATH, "OUTPUT")
     og_spec = {'frisch': 0.41, 'debt_ratio_ss': 1.0,
                'g_y_annual': g_y_annual}
+    runner(output_base=output_base, baseline_dir=input_dir, test=False,
+           time_path=False, baseline=True, og_spec=og_spec,
+           run_micro=False, data=PUF_PATH)
+
+
+@pytest.mark.full_run
+@pytest.mark.parametrize('sigma', [1.3, 1.5, 1.7, 1.9],
+                         ids=['sigma=1.3', 'sigma=1.5', 'sigma=1.7',
+                              'sigma=1.9'])
+def test_sigma(sigma):
+    output_base = os.path.join(CUR_PATH, "OUTPUT")
+    input_dir = os.path.join(CUR_PATH, "OUTPUT")
+    og_spec = {'frisch': 0.41, 'debt_ratio_ss': 1.0,
+               'sigma': sigma}
     runner(output_base=output_base, baseline_dir=input_dir, test=False,
            time_path=False, baseline=True, og_spec=og_spec,
            run_micro=False, data=PUF_PATH)


### PR DESCRIPTION
With the default starting values, the SS solutions fails to be obtained with values of sigma far from the default of 1.5.

This PR sets up tests for a range of sigma values and sets the bounds in `default_parameters.json` to ensure that users enter a sigma in this range.