### PR TITLE
Update default start year

### DIFF
--- a/ogusa/tests/test_basic.py
+++ b/ogusa/tests/test_basic.py
@@ -64,7 +64,7 @@ def test_constant_demographics_TPI():
     ss_outputs = SS.run_SS(spec, None)
     # save SS results
     utils.mkdirs(os.path.join(baseline_dir, "SS"))
-    ss_dir = os.path.join(baseline_dir, "SS/SS_vars.pkl")
+    ss_dir = os.path.join(baseline_dir, "SS", "SS_vars.pkl")
     with open(ss_dir, "wb") as f:
         pickle.dump(ss_outputs, f)
     # Run TPI

--- a/ogusa/tests/test_get_micro_data.py
+++ b/ogusa/tests/test_get_micro_data.py
@@ -97,11 +97,11 @@ def test_get_data():
         os.path.join(CUR_PATH, 'test_io_data',
                      'micro_data_dict_for_tests.pkl'))
     test_data, _ = get_micro_data.get_data(
-        baseline=True, start_year=2028, reform={}, data='cps',
+        baseline=True, start_year=2029, reform={}, data='cps',
         client=None, num_workers=1)
     for k, v in test_data.items():
         assert_frame_equal(
-            expected_data[k], v.drop(columns='payroll_tax_liab'))
+            expected_data[k], v)
 
 
 @pytest.mark.full_run

--- a/ogusa/utils.py
+++ b/ogusa/utils.py
@@ -24,10 +24,10 @@ REFORM_DIR = "OUTPUT_REFORM"
 BASELINE_DIR = "OUTPUT_BASELINE"
 
 # Default year for model runs
-DEFAULT_START_YEAR = 2018
+DEFAULT_START_YEAR = 2020
 
 # Latest year TaxData extrapolates to
-TC_LAST_YEAR = 2028
+TC_LAST_YEAR = 2029
 
 # Year of data used (e.g. PUF or CPS year)
 CPS_START_YEAR = taxcalc.Records.CPSCSV_YEAR


### PR DESCRIPTION
This PR updates the default start year for OG-USA from 2018 to 2020.  It also sets the max year for Tax-Calculator reforms to 2029 (it was 2028).