### PR TITLE
add version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 with open('README.md') as f:
         longdesc = f.read()
 
-version = '0.0.0'
+version = '0.5.13'
 
 config = {
     'description': 'General equilibribum, overlapping generations model for the USA',


### PR DESCRIPTION
This PR adds the OG-USA version number to `setup.py`.  This had been set a 0.0.0 as would be assigned to a built package made in Package Builder based on the most recent tag in Git.  But Package Builder has failed to build  OG-USA for some time and the package is being built directly from this GitHub repo for Compute.Studio.  Therefore, it'll be important to keep the model version current in `setup.py`.