### PR TITLE
Update cs-functions package to work on compute-studio celery worker

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -139,8 +139,10 @@ def run_model(meta_param_dict, adjustment):
         utils.mkdirs(_dir)
 
     # Dask parmeters
-    client = Client()
-    num_workers = 4
+    # Limit to one worker and one thread to satisfy celery
+    # constraints on multiprocessing.
+    client = Client(n_workers=1, threads_per_worker=1, processes=False)
+    num_workers = 1
 
     # whether to estimate tax functions from microdata
     run_micro = True
@@ -194,6 +196,11 @@ def run_model(meta_param_dict, adjustment):
 
     comp_dict = comp_output(base_ss, base_params, reform_ss,
                             reform_params)
+
+    # Shut down client and make sure all of its references are
+    # cleaned up.
+    client.close()
+    del client
 
     return comp_dict
 


### PR DESCRIPTION
- Sets processes to false and limits to one thread per worker
- Closes dask client to fix a memory leak that grows over repeated runs