### PR TITLE
Set version to current

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -65,7 +65,7 @@ class MetaParams(paramtools.Parameters):
 
 
 def get_version():
-    return ogusa.__version__
+    return "0.6.0"
 
 
 def get_inputs(meta_param_dict):


### PR DESCRIPTION
@jdebacker C/S caches the inputs for a model with its version and meta parameters. If the version isn't updated, then stale updates will be used.