### PR TITLE
Add ipython as dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 - conda-forge
 dependencies:
 - python
+- ipython
 - setuptools
 - mkl
 - "scipy>=0.18.1"


### PR DESCRIPTION
This PR adds `iPython` as a dependency, as suggested in Issue #558 