### PR TITLE
Allow more workers on CS

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -155,10 +155,12 @@ def run_model(meta_param_dict, adjustment):
         utils.mkdirs(_dir)
 
     # Dask parmeters
-    # Limit to one worker and one thread to satisfy celery
-    # constraints on multiprocessing.
-    client = Client(n_workers=1, threads_per_worker=1, processes=False)
-    num_workers = 1
+    client = Client()
+    num_workers = 5
+    # TODO: Swap to these parameters when able to specify tax function
+    # and model workers separately
+    # num_workers_txf = 5
+    # num_workers_mod = 6
 
     # whether to estimate tax functions from microdata
     run_micro = True


### PR DESCRIPTION
This just bumps then number of allowed workers from 1 to 5. I've tested this on the C/S dev server with good results:

![Screenshot from 2020-05-25 16-09-32](https://user-images.githubusercontent.com/9206065/82929414-9a699700-9f51-11ea-9c8b-560ff5bdbe86.png)
