### PR TITLE
Update market income definition

### DIFF
--- a/ogusa/get_micro_data.py
+++ b/ogusa/get_micro_data.py
@@ -165,8 +165,7 @@ def taxcalc_advance(baseline, start_year, reform, data, year):
     # define market income - taking expanded_income and excluding gov't
     # transfer benefits found in the Tax-Calculator expanded income
     market_income = (calc1.array('expanded_income') -
-                     calc1.array('benefit_value_total') -
-                     calc1.array('ubi'))
+                     calc1.array('benefit_value_total'))
 
     # Compute mtr on capital income
     mtr_combined_capinc = cap_inc_mtr(calc1)


### PR DESCRIPTION
This PR updates the market income calculation in `get_micro_data.py` to be consistent with the new definitions of `benefits_value_total` from Tax-Calculator that includes UBI benefits after [PR #2418](https://github.com/PSLmodels/Tax-Calculator/pull/2418).