### PR TITLE
Build and deploy only for upstream repo

### DIFF
--- a/.github/workflows/deploy_sphinx.yml
+++ b/.github/workflows/deploy_sphinx.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   build-and-deploy:
+    if: github.repository == 'PSLmodels/OG-USA'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR modifies the GH action build and deploy the docs to only execute the action for the upstream repo (`PSLmodels/OG-USA`).