### PR TITLE
Add doc check for building Jupyter-Book docs

### DIFF
--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -1,23 +1,22 @@
-name: "Check that docs build"
-
+name: Check that docs build
 on: [push, pull_request]
 
 jobs:
-  # Build the book to make sure that building the docs works
-  build-book:
-    name: Build docs
+  build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.7
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[sphinx]
-    - name: Build the book
-      run: |
-        jb build docs/
+      - name: Setup Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          activate-environment: ogusa-dev
+          environment-file: environment.yml
+          python-version: 3.7
+          auto-activate-base: false
+
+      - name: Build # Build Jupyter Book
+        shell: bash -l {0}
+        run: |
+          pip install jupyter-book
+          pip install -e .
+          cd docs
+          jb build ./book

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -5,6 +5,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+  
       - name: Setup Miniconda
         uses: goanpeca/setup-miniconda@v1
         with:

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -3,8 +3,6 @@ name: "Check that docs build"
 on: [push, pull_request]
 
 jobs:
-  pre-commit:
-
   # Build the book to make sure that building the docs works
   build-book:
     name: Build docs

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -1,12 +1,25 @@
-name: "Pull Request Docs Check"
-on: 
-- pull_request
+name: "Check that docs build"
+
+on: [push, pull_request]
 
 jobs:
-  docs:
+  pre-commit:
+
+  # Build the book to make sure that building the docs works
+  build-book:
+    name: Build docs
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@master
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
       with:
-        docs-folder: "./docs"
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[sphinx]
+    - name: Build the book
+      run: |
+        jb build docs/


### PR DESCRIPTION
This PR updates the `docs_check` github action to check that the Jupyter-Book documentation builds.  A build failure should be indicated by a failure of this action to build the docs.