### PR TITLE
Updates to use checked in data, fewer processors

### DIFF
--- a/ogusa/tests/test_execute.py
+++ b/ogusa/tests/test_execute.py
@@ -4,10 +4,12 @@ import pytest
 from ogusa import SS, TPI
 from ogusa.execute import runner
 import os
-NUM_WORKERS = min(multiprocessing.cpu_count(), 7)
+NUM_WORKERS = min(multiprocessing.cpu_count(), 2)
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 BASELINE_DIR = os.path.join(CUR_PATH, 'OUTPUT_BASELINE')
 REFORM_DIR = os.path.join(CUR_PATH, 'OUTPUT_REFORM')
+BASE_TAX = os.path.join(CUR_PATH, 'TxFuncEst_baseline.pkl')
+REFORM_TAX = os.path.join(CUR_PATH, 'TxFuncEst_policy.pkl')
 
 # Monkey patch enforcement flag since small data won't pass checks
 SS.ENFORCE_SOLUTION_CHECKS = False
@@ -27,12 +29,16 @@ def dask_client():
 @pytest.mark.full_run
 def test_runner_baseline(dask_client):
     runner(output_base=BASELINE_DIR, baseline_dir=BASELINE_DIR,
-           test=True, time_path=True, baseline=True, run_micro=False,
-           data='cps', client=dask_client, num_workers=NUM_WORKERS)
+           test=True, time_path=True, baseline=True,
+           og_spec={'start_year': 2018}, run_micro=False,
+           tax_func_path=BASE_TAX, data='cps', client=dask_client,
+           num_workers=NUM_WORKERS)
 
 
 @pytest.mark.full_run
 def test_runner_reform(dask_client):
     runner(output_base=REFORM_DIR, baseline_dir=BASELINE_DIR,
-           test=True, time_path=False, baseline=False, run_micro=False,
-           data='cps', client=dask_client, num_workers=NUM_WORKERS)
+           test=True, time_path=False, baseline=False,
+           og_spec={'start_year': 2018}, run_micro=False,
+           tax_func_path=REFORM_TAX, data='cps', client=dask_client,
+           num_workers=NUM_WORKERS)

--- a/ogusa/tests/test_execute.py
+++ b/ogusa/tests/test_execute.py
@@ -4,7 +4,7 @@ import pytest
 from ogusa import SS, TPI
 from ogusa.execute import runner
 import os
-NUM_WORKERS = min(multiprocessing.cpu_count(), 2)
+NUM_WORKERS = min(multiprocessing.cpu_count(), 7)
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 BASELINE_DIR = os.path.join(CUR_PATH, 'OUTPUT_BASELINE')
 REFORM_DIR = os.path.join(CUR_PATH, 'OUTPUT_REFORM')
@@ -40,5 +40,5 @@ def test_runner_reform(dask_client):
     runner(output_base=REFORM_DIR, baseline_dir=BASELINE_DIR,
            test=True, time_path=False, baseline=False,
            og_spec={'start_year': 2018}, run_micro=False,
-           tax_func_path=REFORM_TAX, data='cps', client=dask_client,
+           tax_func_path=None, data='cps', client=dask_client,
            num_workers=NUM_WORKERS)

--- a/ogusa/tests/test_run_ogusa.py
+++ b/ogusa/tests/test_run_ogusa.py
@@ -28,16 +28,15 @@ def run_micro_macro(iit_reform, og_spec, guid, client):
     guid = ''
     start_time = time.time()
 
-    REFORM_DIR = "./OUTPUT_REFORM_" + guid
-    BASELINE_DIR = "./OUTPUT_BASELINE_" + guid
-    tax_func_path_baseline = os.path.join(CUR_PATH, 'OUTPUT_BASELINE',
-                                          'TxFuncEst_baseline.pkl')
-    tax_func_path_reform = os.path.join(CUR_PATH, 'OUTPUT_REFORM',
-                                        'TxFuncEst_policy.pkl')
+    REFORM_DIR = os.path.join(CUR_PATH, "OUTPUT_REFORM_" + guid)
+    BASELINE_DIR = os.path.join(CUR_PATH, "OUTPUT_BASELINE" + guid)
+    tax_func_path_baseline = os.path.join(
+        CUR_PATH, 'TxFuncEst_baseline.pkl')
+    tax_func_path_reform = os.path.join(
+        CUR_PATH, 'TxFuncEst_policy.pkl')
 
     # Add start year from reform to user parameters
-    start_year = sorted(iit_reform.keys())[0]
-    og_spec['start_year'] = start_year
+    og_spec['start_year'] = 2018
 
     with open("log_{}.log".format(guid), 'w') as f:
         f.write("guid: {}\n".format(guid))
@@ -94,15 +93,15 @@ def run_micro_macro(iit_reform, og_spec, guid, client):
 def test_run_micro_macro(dask_client):
 
     iit_reform = {
-        2018: {
-            '_II_rt1': [.09],
-            '_II_rt2': [.135],
-            '_II_rt3': [.225],
-            '_II_rt4': [.252],
-            '_II_rt5': [.297],
-            '_II_rt6': [.315],
-            '_II_rt7': [0.3564],
-            }, }
+        "II_rt1": {2018: 0.09},
+        "II_rt2": {2018: 0.135},
+        "II_rt3": {2018: 0.225},
+        "II_rt4": {2018: 0.252},
+        "II_rt5": {2018: 0.297},
+        "II_rt6": {2018: 0.315},
+        "II_rt7": {2018: 0.3564}
+    }
+        
     run_micro_macro(iit_reform=iit_reform, og_spec={
         'frisch': 0.44, 'g_y_annual': 0.021}, guid='abc',
                     client=dask_client)


### PR DESCRIPTION
This PR updates the `test_execute.py` and `test_run_ogusa.py` modules to use data that is already checked in to the repository.

These tests do not run on Travis CI due to time constraints.  Previous to this PR, those running these tests had the necessary data files on their hard drives, but others may not have.  This PR will ensure that anyone cloning this repo can run these tests locally without additional files.