### PR TITLE
Linear tax rate calculations

### DIFF
--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -469,7 +469,8 @@ def txfunc_est(df, s, t, rate_type, tax_func_type, numparams,
         params = np.zeros(numparams)
         wsse = 0.0
         obs = df.shape[0]
-        params[10] = txrates.mean()
+        params[10] = (
+            (txrates * wgts * income).sum() / (income * wgts).sum())
         params_to_plot = params[1:11]
     else:
         raise RuntimeError("Choice of tax function is not in the set of"


### PR DESCRIPTION
This PR updates the estimation of linear tax functions to be computed as income weighted averages.  This ensures that those rates more closely represent the effective tax rates on the average dollar of income (as opposed to an average across tax filing units).