### PR TITLE
Update link for PSL catalog to point to Jupyter Book

### DIFF
--- a/PSL_catalog.json
+++ b/PSL_catalog.json
@@ -93,9 +93,9 @@
     "contributor_guide": {
         "start_header": null,
         "end_header": null,
-        "source": "https://og-usa.readthedocs.io/en/latest/",
+        "source": "https://pslmodels.github.io/OG-USA",
         "type": null,
-        "data": "<a href=\"https://og-usa.readthedocs.io/en/latest/\">Contributor documentation</a>"
+        "data": "<a href=\"https://pslmodels.github.io/OG-USA\">Contributor documentation</a>"
     },
     "governance_overview": {
         "start_header": null,


### PR DESCRIPTION
This PR updates a link to OG-USA documentation for the [PSL catalog page](https://www.pslmodels.org/Catalog/index.html) to point to the Jupyter Book documentation instead of the readthedocs page, which has been pulled down. 