### PR TITLE
Fix test in test_get_micro_data.py

### DIFF
--- a/ogusa/tests/test_get_micro_data.py
+++ b/ogusa/tests/test_get_micro_data.py
@@ -141,8 +141,7 @@ def test_get_calculator_puf():
         }
     calc = get_micro_data.get_calculator(
         baseline=False, calculator_start_year=2017, reform=iit_reform,
-        data=None,
-        records_start_year=PUF_START_YEAR)
+        data=PUF_PATH, records_start_year=PUF_START_YEAR)
     assert calc.current_year == 2013
 
 


### PR DESCRIPTION
I ran the full set of tests on the OG-USA master branch with most recent commit [d3c38c7f](https://github.com/PSLmodels/OG-USA/commit/d3c38c7fcee65d5942420d8baeb7f86326a80775) (up to PR #663). One test failed in `test_get_micro_data.py` in the [`test_get_calculator_puf()`](https://github.com/PSLmodels/OG-USA/blob/master/ogusa/tests/test_get_micro_data.py#L132) function. The function could not find the `puf.csv` file. The fix was simply to add `PUF_PATH` to the function call. Now it passes.
```
...

ogusa/tests/test_get_micro_data.py ........F.....                        [ 20%]

...

self = <pkg_resources.PathMetadata object at 0x7ff4c29c9430>
manager = <pkg_resources.ResourceManager object at 0x7ff4c28fdac0>
resource_name = 'taxcalc/puf.csv'

    def get_resource_stream(self, manager, resource_name):
>       return open(self._fn(self.module_path, resource_name), 'rb')
E       FileNotFoundError: [Errno 2] No such file or directory: '/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.8/site-packages/taxcalc/puf.csv'

../../../../opt/anaconda3/envs/ogusa-dev/lib/python3.8/site-packages/pkg_resources/__init__.py:1623: FileNotFoundError

During handling of the above exception, another exception occurred:

    @pytest.mark.full_run
    def test_get_calculator_puf():
        iit_reform = {
            'II_rt1': {2017: 0.09},
            'II_rt2': {2017: 0.135},
            'II_rt3': {2017: 0.225},
            'II_rt4': {2017: 0.252},
            'II_rt5': {2017: 0.297},
            'II_rt6': {2017: 0.315},
            'II_rt7': {2017: 0.3564}
            }
>       calc = get_micro_data.get_calculator(
            baseline=False, calculator_start_year=2017, reform=iit_reform,
            data=None,
            records_start_year=PUF_START_YEAR)

ogusa/tests/test_get_micro_data.py:142: 
```

cc: @jdebacker 