### PR TITLE
Describe additional tax functions

### DIFF
--- a/docs/book/content/calibration/tax_functions.md
+++ b/docs/book/content/calibration/tax_functions.md
@@ -237,20 +237,21 @@ The second difficulty in modeling realistic tax and incentive detail is the need
 
 ### Alternative Functional Forms
 
-In addition to the default option using tax functions of the form developed by {cite}`DeBackerEtAl:2017`, `OG-USA` also allows users to specify alternative tax functions.  Three alternatives are offered:
+  In addition to the default option using tax functions of the form developed by {cite}`DeBackerEtAl:2017`, `OG-USA` also allows users to specify alternative tax functions.  Three alternatives are offered:
 
-1. Functions as in {cite}`DeBackerEtAl:2017`, but where $\tau^{etr}_{s,t}$, $\tau^{mtrx}_{s,t}$, and $\tau^{mtry}_{s,t}$ are functions of total income (i.e., $x+y$) and not labor and capital income separately.  Users can select this option by setting the parameter `tax_func_type="DEP_totalinc"`.
-2. Functions of the form of {cite}`GouveiaStrauss:1994`: 
+  1. Functions as in {cite}`DeBackerEtAl:2017`, but where $\tau^{etr}_{s,t}$, $\tau^{mtrx}_{s,t}$, and $\tau^{mtry}_{s,t}$ are functions of total income (i.e., $x+y$) and not labor and capital income separately.  Users can select this option by setting the parameter `tax_func_type="DEP_totalinc"`.
   
-  ```{math}
-  \tau = \phi_{0}(1 - (x+y)^{(\phi_{1}-1)}((x+y)^{-\phi1} + \phi_{2})^{(-1 - \phi_{1})/\phi_{1}})
-  ```
-   
-   * Users can select this option by setting the parameter `tax_func_type="GS"`.  The three parameters of this function ($phi_{0}, \phi_{1}, \phi_{2}$) are estimated using the weighted sum of squares estimated described in Equation {eq}`EqTaxCalcThetaWSSQ`.
+  2. Functions of the form of {cite}`GouveiaStrauss:1994`: 
+    
+     ```{math}
+       \tau = \phi_{0}(1 - (x+y)^{(\phi_{1}-1)}((x+y)^{-\phi1} + \phi_{2})^{(-1 - \phi_{1})/\phi_{1}})
+     ```
+    
+      Users can select this option by setting the parameter `tax_func_type="GS"`.  The three parameters of this function ($phi_{0}, \phi_{1}, \phi_{2}$) are estimated using the weighted sum of squares estimated described in Equation {eq}`EqTaxCalcThetaWSSQ`.
 
-3. Linear tax functions (i.e., $\tau =$ a constant).  Users can select this option by setting the parameter `tax_func_type="linear"`.  The constant rate is found by taking the weighted average of the appropriate tax rate (effective tax rate, marginal tax rate on labor income, marginal tax rate on labor income) for each age and year, where the values are weighted by sampling weights and income.
+  1. Linear tax functions (i.e., $\tau =$ a constant).  Users can select this option by setting the parameter `tax_func_type="linear"`.  The constant rate is found by taking the weighted average of the appropriate tax rate (effective tax rate, marginal tax rate on labor income, marginal tax rate on labor income) for each age and year, where the values are weighted by sampling weights and income.
 
-Among all of these tax functional forms, users can set the `age_specific` parameter to `False` if they wish to have one function for all ages `s`.  In addition, the functions based on {cite}`DeBackerEtAl:2017` (`tax_func_type="DEP"` or `tax_func_type="DEP_totinc"`), one can set `analytical_mtrs=True` if they wish to have the $\tau^{mtrx}_{s,t}$ and $\tau^{mtry}_{s,t}$ derived from the $\tau^{etr}_{s,t}$ functions.  This provides theoretical consistency, but reduced fit of the functions (see {cite}`DeBackerEtAl:2017` for more details).
+  Among all of these tax functional forms, users can set the `age_specific` parameter to `False` if they wish to have one function for all ages `s`.  In addition, the functions based on {cite}`DeBackerEtAl:2017` (`tax_func_type="DEP"` or `tax_func_type="DEP_totinc"`), one can set `analytical_mtrs=True` if they wish to have the $\tau^{mtrx}_{s,t}$ and $\tau^{mtry}_{s,t}$ derived from the $\tau^{etr}_{s,t}$ functions.  This provides theoretical consistency, but reduced fit of the functions (see {cite}`DeBackerEtAl:2017` for more details).
 
 (SecTaxCalcFactor)=
 ## Factor Transforming Income Units

--- a/docs/book/content/calibration/tax_functions.md
+++ b/docs/book/content/calibration/tax_functions.md
@@ -90,7 +90,9 @@ The second difficulty in modeling realistic tax and incentive detail is the need
 
   In looking at the 2D scatter plot on effective tax rates as a function of total income in Figure {numref}`FigTaxCalcETRtotinc` and the 3D scatter plots of $ETR$, $MTRx$, and $MTRy$ in Figure {numref}`FigTaxCalc3Dtaxrates`, it is clear that all of these rates exhibit negative exponential or logistic shape. This empirical regularity allows us to make an important and nonrestrictive assumption. We can fit parametric tax rate functions to these data that are constrained to be monotonically increasing in labor income and capital income. This assumption of monotonicity is computationally important as it preserves a convex budget set for each household, which is important for being able to solve many household lifetime problems over a large number of periods.
 
-  `OG-USA` follows the approach of {cite}`DeBackerEtAl:2017` in using the following functional form to estimate tax functions for each age $s=E+1, E+2, ... E+S$ in each time period $t$. Equation {ref}`EqTaxCalcTaxFuncForm} is written as a generic tax rate, but we use this same functional form for $ETR$'s, $MTRx$'s, and $MTRy$'s.
+### Default Tax Functional Form
+
+  For the default option, `OG-USA` follows the approach of {cite}`DeBackerEtAl:2017` in using the following functional form to estimate tax functions for each age $s=E+1, E+2, ... E+S$ in each time period $t$. Equation {ref}`EqTaxCalcTaxFuncForm} is written as a generic tax rate, but we use this same functional form for $ETR$'s, $MTRx$'s, and $MTRy$'s.
   ```{math}
   :label: EqTaxCalcTaxFuncForm
       \tau(x,y) = &\Bigl[\tau(x) + shift_x\Bigr]^\phi\Bigl[\tau(y) + shift_y\Bigr]^{1-\phi} + shift \\
@@ -232,6 +234,23 @@ The second difficulty in modeling realistic tax and incentive detail is the need
   In `OG-USA`, we estimate the 12-parameter functional form {eq}`EqTaxCalcTaxFuncForm` using weighted nonlinear least squares to fit an effective tax rate function $(\tau^{etr}_{s,t})$, a marginal tax rate of labor income function $(\tau^{mtrx}_{s,t})$, and a marginal tax rate of capital income function $(\tau^{mtry}_{s,t})$ for each age $E+1\leq s\leq E+S$ and each of the first 10 years from the current period. [^param_note] That means we have to perform 2,400 estimations of 12 parameters each. Figure {numref}`FigTaxCalc3DvsPred` shows the predicted surfaces for $\tau^{etr}_{s=42,t=2017}$, $\tau^{mtrx}_{s=42,t=2017}$, and $\tau^{mtry}_{s=42,t=2017}$ along with the underlying scatter plot data from which those functions were estimated. {numref}`TabTaxCalcEst42` shows the estimated values of those functional forms.
 
   The full set of estimated values are calculated in the [`OG-USA/ogusa/txfunc.py`](https://github.com/open-source-economics/OG-USA/blob/master/ogusa/txfunc.py) module in the `OG-USA` repository. And the estimated values are stored in the [`TxFuncEst_baseline.pkl`](https://github.com/open-source-economics/OG-USA/blob/master/TxFuncEst_baseline.pkl) file.
+
+### Alternative Functional Forms
+
+In addition to the default option using tax functions of the form developed by {cite}`DeBackerEtAl:2017`, `OG-USA` also allows users to specify alternative tax functions.  Three alternatives are offered:
+
+1. Functions as in {cite}`DeBackerEtAl:2017`, but where $\tau^{etr}_{s,t}$, $\tau^{mtrx}_{s,t}$, and $\tau^{mtry}_{s,t}$ are functions of total income (i.e., $x+y$) and not labor and capital income separately.  Users can select this option by setting the parameter `tax_func_type="DEP_totalinc"`.
+2. Functions of the form of {cite}`GouveiaStrauss:1994`: 
+  
+  ```{math}
+  \tau = \phi_{0}(1 - (x+y)^{(\phi_{1}-1)}((x+y)^{-\phi1} + \phi_{2})^{(-1 - \phi_{1})/\phi_{1}})
+  ```
+   
+   * Users can select this option by setting the parameter `tax_func_type="GS"`.  The three parameters of this function ($phi_{0}, \phi_{1}, \phi_{2}$) are estimated using the weighted sum of squares estimated described in Equation {eq}`EqTaxCalcThetaWSSQ`.
+
+3. Linear tax functions (i.e., $\tau =$ a constant).  Users can select this option by setting the parameter `tax_func_type="linear"`.  The constant rate is found by taking the weighted average of the appropriate tax rate (effective tax rate, marginal tax rate on labor income, marginal tax rate on labor income) for each age and year, where the values are weighted by sampling weights and income.
+
+Among all of these tax functional forms, users can set the `age_specific` parameter to `False` if they wish to have one function for all ages `s`.  In addition, the functions based on {cite}`DeBackerEtAl:2017` (`tax_func_type="DEP"` or `tax_func_type="DEP_totinc"`), one can set `analytical_mtrs=True` if they wish to have the $\tau^{mtrx}_{s,t}$ and $\tau^{mtry}_{s,t}$ derived from the $\tau^{etr}_{s,t}$ functions.  This provides theoretical consistency, but reduced fit of the functions (see {cite}`DeBackerEtAl:2017` for more details).
 
 (SecTaxCalcFactor)=
 ## Factor Transforming Income Units


### PR DESCRIPTION
This PR addresses Issue #616 by describing the three alternative tax functions users can select:

1. `DEP_totalinc`
2. Gouveia and Strauss (1994) functional form.
3. Linear tax functions

In addition, the `age_specific` and `analytical_mtr` options are noted.