### PR TITLE
Compress large file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,5 @@ dependencies:
 - pip:
   - jupyter-book>=0.8.0
   - cs-kit
-  - xlrd
+  - xlrd==1.2.0
   - cs2tc

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -184,6 +184,9 @@ def test_tax_data_sample():
     assert isinstance(df, pd.DataFrame)
 
 
+@pytest.mark.full_run
+# mark as full run since results work on Mac, but differ on other
+# platforms
 def test_tax_func_loop():
     '''
     Test txfunc.tax_func_loop() function.  The test is that given

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -1,10 +1,11 @@
 from ogusa import txfunc
-import multiprocessing
 from distributed import Client, LocalCluster
 import pytest
 import pandas as pd
 import numpy as np
 import os
+import pickle
+import bz2
 from ogusa import utils
 NUM_WORKERS = 2
 CUR_PATH = os.path.abspath(os.path.dirname(__file__))
@@ -19,6 +20,12 @@ def dask_client():
     client.close()
     cluster.close()
 
+
+# function to decompress pickle file
+def decompress_pickle(file):
+    data = bz2.BZ2File(file, 'rb')
+    data = pickle.load(data)
+    return data
 
 @pytest.mark.parametrize('tax_func_type,expected',
                          [('DEP', 0.032749763), ('GS', 0.007952744)],
@@ -187,9 +194,12 @@ def test_tax_func_loop():
     won't be available there.
 
     '''
-    input_tuple = utils.safe_read_pickle(
+    # input_tuple = utils.safe_read_pickle(
+    #     os.path.join(CUR_PATH, 'test_io_data',
+    #                  'tax_func_loop_inputs_large.pkl'))
+    input_tuple = decompress_pickle(
         os.path.join(CUR_PATH, 'test_io_data',
-                     'tax_func_loop_inputs_large.pkl'))
+                     'tax_func_loop_inputs_large.pbz2'))
     (t, micro_data, beg_yr, s_min, s_max, age_specific, analytical_mtrs,
      desc_data, graph_data, graph_est, output_dir, numparams,
      tpers) = input_tuple

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -194,9 +194,6 @@ def test_tax_func_loop():
     won't be available there.
 
     '''
-    # input_tuple = utils.safe_read_pickle(
-    #     os.path.join(CUR_PATH, 'test_io_data',
-    #                  'tax_func_loop_inputs_large.pkl'))
     input_tuple = decompress_pickle(
         os.path.join(CUR_PATH, 'test_io_data',
                      'tax_func_loop_inputs_large.pbz2'))

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -184,7 +184,6 @@ def test_tax_data_sample():
     assert isinstance(df, pd.DataFrame)
 
 
-@pytest.mark.full_run
 def test_tax_func_loop():
     '''
     Test txfunc.tax_func_loop() function.  The test is that given


### PR DESCRIPTION
This PR addressed Issue #623.  It does so by compressing the pickle file used in the `test_txfunc.py::test_tax_func_loop` unit test using the `bz2` package.  

Thanks to @chusloj for this suggestion.