### PR TITLE
Pin Dask version in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,9 @@ dependencies:
 - pandas>=1.0.5
 - matplotlib
 - taxcalc>=3.0.0
-- dask>=2.20.0
+- dask==2.30.0
+- dask-core==2.30.0
+- distributed==2.30.1
 - paramtools>=0.15.0
 - openpyxl
 - sphinx>=3.1.2


### PR DESCRIPTION
This PR pins the versions for the `dask`, `dask-core`, and `distributed` packages in the `environment.yml` file, which generates the `ogusa-dev` conda environment.
```python
dask==2.30.0
dask-core==2.30.0
distributed==2.30.1
```
I do this because I could not get the TPI section of the code to run with the updated 2020.12.0 versions of the three packages. I propose that we merge this PR, then work on making OG-USA run with the updated Dask packages in a future PR.

I recently updated my `ogusa-dev` conda environment to reflect changes in recent PRs. This updated many of the packages in my enviroment. When I ran a reform on my machine (Biden reform for TPC), the computation failed at the baseline TPI stage. It is worth noting that the tax functions were precomputed on a different machine from mine (@jdebacker), so that part of the computation was not part of my experiment. The error I got was the following, which looked like a `Dask` error in the parallel processing portion of the TPI code.
```
distributed.worker - WARNING -  Compute Failed
Function:  execute_task
args:      ((<function inner_loop at 0x7fdf4905f790>, (<class 'tuple'>, [array([[ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933],
       [ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933],
       [ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933],
       ...,
       [ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933],
       [ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933],
       [ 0.12720666,  0.20570074,  0.2791178 , ..., 16.42250693,
        17.30345988, 18.59072933]]), array([[0.31169705, 0.30508937, 0.33644309, ..., 0.12355504, 0.11974312,
        0.11715169],
       [0.31169705, 0.30508937, 0.33644309, ..., 0.12355504, 0.11974312,
        0.11715169],
       [0.31169705, 0.30508937, 0.33644309, ..., 0.12355504, 0.11974312,
        0.11715169],
       ...,
       [0.31169705, 0.30508937
kwargs:    {}
Exception: ValueError('assignment destination is read-only')
```
This error was displayed four times, coming from four different processors. When @jdebacker ran the same policy simulation, it executed completely on his computer. I compared conda lists and found the following differences.
```
                |  Rick     |  Jason
package         | version   | version
----------------+-----------+--------
aiohttp         |   3.7.3   |  3.6.2   
backports       |   1.0     |    X
backports.fu...
nctiontools_...
lru_cache       |  1.6.1    |    X
beautifulsoup4  |   4.9.3   |  4.9.1
blas            |     X     |  1.0
ca-certificates | 2020.12.5 | 2020.12.8
cachetools      |   4.2.0   |  4.1.1
colorama        |   0.4.4   |  0.4.3
coverage        |   5.3.1   |  5.3
dask            | 2020.12.0 |  2.30.0
dask-core       | 2020.12.0 |  2.30.0
distributed     | 2020.12.0 |  2.30.1
fsspec          |   0.8.5   |  0.8.3
gitpython       |   3.1.11  |  3.1.8
google-auth     |   1.24.0  |  1.21.3
google-auth-oauthlib | 0.4.2 | 0.4.1
importlib-metadata | 3.3.0  |  2.0.0
ipykernel       |   5.4.2   |  5.3.4
jpeg            |     9d    |    9b
json5           |     X     |  0.9.5
jupyterlab      |     X     |  2.2.6
jupyterlab_...
pygments        |     X     |  0.1.2
jupyterlab_...
server          |     X     |  1.2.0
kiwisolver      |   1.3.1   |  1.3.0
libblas         |   3.9.0   |    X
libcblas        |   3.9.0   |    X
libcxx          |  11.0.0   | 10.0.0
libedit         |     X     | 3.1.20191231
libgfortran     |   5.0.0   |  3.0.1
libgfortran5    |   9.3.0   |    X
liblapack       |   3.9.0   |    X
libopenblas     |   0.3.12  |  0.3.10
libsass         |     X     |  0.20.1
libsodium       |     X     |  1.0.18
libtiff         |   4.2.0   |  4.1.0
libwebp-base    |   1.1.0   |    X
llvm-openmp     |  11.0.0   | 10.0.0
llvmlite        |   0.35.0  |  0.34.0
markdown-it-py  |   0.5.8   |  0.5.4
marshmallow     |   3.10.0  |  3.9.1
matplotlib      |   3.3.3   |  3.3.2
matplotlib-base |   3.3.3   |  3.3.2
mkl             |   2020.4  |  2020.2
msgpack-python  |   1.0.2   |  1.0.0
multidict       |   5.1.0   |  4.7.6
nbdime          |   2.1.0   |  2.0.0
notebook        |   6.1.5   |  6.1.4
numba           |   0.52.0  |  0.51.2
numpy           |   1.19.4  |  1.19.2
numpy-base      |     X     |  1.19.2
packaging       |    20.8   |   20.7        
pandas          |   1.1.5   |  1.1.3       
pandocfilters   |   1.4.3   |  1.4.2
parso           |   0.7.1   |  0.7.0
pip             |   20.3.3  |  20.3.1
psutil          |   5.8.0   |  5.7.2
py              |   1.10.0  |  1.9.0
pybtex          |   0.23.0  |  0.22.2
pyopenssl       |   20.0.1  |  20.0.0
pytest          |   6.2.1   |  6.1.2
pytest-forked   |   1.2.0   |  1.3.0
pytest-xdist    |   2.2.0   |  2.1.0
python          |   3.8.6   |  3.8.5
python_abi      |    3.8    |    X
pyzmq           |   20.0.0  |  19.0.2
requests        |   2.25.1  |  2.25.0
scipy           |   1.5.3   |  1.5.2
setuptools      |   49.6.0  |  51.0.0
soupsieve       |     2.1   |  2.0.1
sphinx          |   3.4.0   |  3.2.1
sphinx-copybutton | 0.3.1   |  0.3.0
sphinx-thebe    |   0.0.8   |  0.0.7
sphinx-togglebutton | 0.2.3 |  0.2.2
sphinxcontrib-bibtex | 2.0.0 | 1.0.0
sqlalchemy      |   1.3.22  |  1.3.19
sqlite          |   3.34.0  |  3.33.0
tblib           |   1.6.0   |  1.7.0
toml            |   0.10.2  |  0.10.1
urllib3         |   1.26.2  |  1.25.1
wheel           |   0.36.2  |  0.36.1
xlrd            |   1.2.0   |  2.0.1
yarl            |   1.6.3   |  1.6.0
zeromq          |     X     |  4.3.3
```
Given the error, a likely culprit for the error was my updated `Dask` packages (`dask`, `dask-core`, and `distributed`). When I pinned those three packages to the versions in Jason's environment (2.30.0, 2.30.0, and 2.30.1, respectively) and updated my environment, the policy simulation executed completely.