### PR TITLE
Fix indexing issue with linear tax rate function

### DIFF
--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -166,7 +166,7 @@ expected_tuple_linear_mtry = (0.15604427, 0.0, 3798)
                            expected_tuple_DEP_totalinc)],
                          ids=['DEP', 'DEP_totalinc'])
 def test_txfunc_est(rate_type, tax_func_type, numparams,
-                    expected_tuple):
+                    expected_tuple, tmpdir):
     '''
     Test txfunc.txfunc_est() function.  The test is that given
     inputs from previous run, the outputs are unchanged.
@@ -174,6 +174,7 @@ def test_txfunc_est(rate_type, tax_func_type, numparams,
     input_tuple = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', 'txfunc_est_inputs.pkl'))
     (df, s, t, _, output_dir, graph) = input_tuple
+    output_dir = tmpdir
     # Put old df variables into new df var names
     df.rename(columns={
         'MTR labor income': 'mtr_labinc',
@@ -199,7 +200,7 @@ def test_txfunc_est(rate_type, tax_func_type, numparams,
                          ids=['linear', 'GS', 'linear, mtrx',
                               'linear, mtry'])
 def test_txfunc_est_on_GH(rate_type, tax_func_type, numparams,
-                          expected_tuple):
+                          expected_tuple, tmpdir):
     '''
     Test txfunc.txfunc_est() function.  The test is that given
     inputs from previous run, the outputs are unchanged.
@@ -207,6 +208,7 @@ def test_txfunc_est_on_GH(rate_type, tax_func_type, numparams,
     input_tuple = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', 'txfunc_est_inputs.pkl'))
     (df, s, t, _, output_dir, graph) = input_tuple
+    output_dir = tmpdir
     # Put old df variables into new df var names
     df.rename(columns={
         'MTR labor income': 'mtr_labinc',

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -163,17 +163,43 @@ expected_tuple_linear_mtry = (0.15604427, 0.0, 3798)
 @pytest.mark.parametrize('rate_type,tax_func_type,numparams,expected_tuple',
                          [('etr', 'DEP', 12, expected_tuple_DEP),
                           ('etr', 'DEP_totalinc', 6,
-                           expected_tuple_DEP_totalinc),
-                          ('etr', 'linear', 1, expected_tuple_linear),
+                           expected_tuple_DEP_totalinc)],
+                         ids=['DEP', 'DEP_totalinc'])
+def test_txfunc_est(rate_type, tax_func_type, numparams,
+                    expected_tuple):
+    '''
+    Test txfunc.txfunc_est() function.  The test is that given
+    inputs from previous run, the outputs are unchanged.
+    '''
+    input_tuple = utils.safe_read_pickle(
+        os.path.join(CUR_PATH, 'test_io_data', 'txfunc_est_inputs.pkl'))
+    (df, s, t, _, output_dir, graph) = input_tuple
+    # Put old df variables into new df var names
+    df.rename(columns={
+        'MTR labor income': 'mtr_labinc',
+        'MTR capital income': 'mtr_capinc',
+        'Total labor income': 'total_labinc',
+        'Total capital income': 'total_capinc', 'ETR': 'etr',
+        'expanded_income': 'market_income',
+        'Weights': 'weight'}, inplace=True)
+    test_tuple = txfunc.txfunc_est(df, s, t, rate_type, tax_func_type,
+                                   numparams, output_dir, True)
+
+    for i, v in enumerate(expected_tuple):
+        assert(np.allclose(test_tuple[i], v))
+
+
+@pytest.mark.parametrize('rate_type,tax_func_type,numparams,expected_tuple',
+                         [('etr', 'linear', 1, expected_tuple_linear),
                           ('etr', 'GS', 3, expected_tuple_GS),
                           ('mtrx', 'linear', 1,
                            expected_tuple_linear_mtrx),
                           ('mtry', 'linear', 1,
                            expected_tuple_linear_mtry)],
-                         ids=['DEP', 'DEP_totalinc', 'linear', 'GS',
-                              'linear, mtrx', 'linear, mtry'])
-def test_txfunc_est(rate_type, tax_func_type, numparams,
-                    expected_tuple):
+                         ids=['linear', 'GS', 'linear, mtrx',
+                              'linear, mtry'])
+def test_txfunc_est_on_GH(rate_type, tax_func_type, numparams,
+                          expected_tuple):
     '''
     Test txfunc.txfunc_est() function.  The test is that given
     inputs from previous run, the outputs are unchanged.

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -140,10 +140,22 @@ def test_replace_outliers():
     assert np.allclose(act, exp)
 
 
+expected_tuple_DEP = ((np.array(
+    [6.37000261e-22, 2.73401629e-03, 1.54672458e-08, 1.43446236e-02,
+        2.32797367e-01, 1.00000000e-04, 1.00000000e+00,
+        -3.69059719e-02, -1.01967001e-01, 3.96030053e-02,
+        1.02987671e-01, -1.30433574e-01]), 19527.16203007729, 3798))
+expected_tuple_linear = (0.15381972028750876, 0.0, 3798)
+
+
 @pytest.mark.full_run  # only marking as full run because platform
 # affects results from scipy.opt that is called in this test - so it'll
 # pass if run on Mac with MKL, but not necessarily on other platforms
-def test_txfunc_est():
+@pytest.mark.parametrize('tax_func_type,numparams,expected_tuple',
+                         [('DEP', 12, expected_tuple_DEP),
+                          ('linear', 1, expected_tuple_linear)],
+                         ids=['DEP', 'linear'])
+def test_txfunc_est(tax_func_type, numparams, expected_tuple):
     '''
     Test txfunc.txfunc_est() function.  The test is that given
     inputs from previous run, the outputs are unchanged.
@@ -159,15 +171,9 @@ def test_txfunc_est():
         'Total capital income': 'total_capinc', 'ETR': 'etr',
         'expanded_income': 'market_income',
         'Weights': 'weight'}, inplace=True)
-    tax_func_type = 'DEP'
-    numparams = 12
     test_tuple = txfunc.txfunc_est(df, s, t, rate_type, tax_func_type,
                                    numparams, output_dir, graph)
-    expected_tuple = ((np.array(
-        [6.37000261e-22, 2.73401629e-03, 1.54672458e-08, 1.43446236e-02,
-         2.32797367e-01, 1.00000000e-04, 1.00000000e+00,
-         -3.69059719e-02, -1.01967001e-01, 3.96030053e-02,
-         1.02987671e-01, -1.30433574e-01]), 19527.16203007729, 3798))
+    print('test_tuple = ', test_tuple)
 
     for i, v in enumerate(expected_tuple):
         assert(np.allclose(test_tuple[i], v))

--- a/ogusa/tests/test_txfunc.py
+++ b/ogusa/tests/test_txfunc.py
@@ -153,26 +153,34 @@ expected_tuple_linear = (0.15381972028750876, 0.0, 3798)
 expected_tuple_GS = (
     np.array([1.29769078e-01, 4.36131826e+00, 4.44887761e-07]),
     20323.465971499016, 3798)
+expected_tuple_linear_mtrx = (0.2677667, 0.0, 3798)
+expected_tuple_linear_mtry = (0.15604427, 0.0, 3798)
 
 
 @pytest.mark.full_run  # only marking as full run because platform
 # affects results from scipy.opt that is called in this test - so it'll
 # pass if run on Mac with MKL, but not necessarily on other platforms
-@pytest.mark.parametrize('tax_func_type,numparams,expected_tuple',
-                         [('DEP', 12, expected_tuple_DEP),
-                          ('DEP_totalinc', 6,
+@pytest.mark.parametrize('rate_type,tax_func_type,numparams,expected_tuple',
+                         [('etr', 'DEP', 12, expected_tuple_DEP),
+                          ('etr', 'DEP_totalinc', 6,
                            expected_tuple_DEP_totalinc),
-                          ('linear', 1, expected_tuple_linear),
-                          ('GS', 3, expected_tuple_GS)],
-                         ids=['DEP', 'DEP_totalinc', 'linear', 'GS'])
-def test_txfunc_est(tax_func_type, numparams, expected_tuple):
+                          ('etr', 'linear', 1, expected_tuple_linear),
+                          ('etr', 'GS', 3, expected_tuple_GS),
+                          ('mtrx', 'linear', 1,
+                           expected_tuple_linear_mtrx),
+                          ('mtry', 'linear', 1,
+                           expected_tuple_linear_mtry)],
+                         ids=['DEP', 'DEP_totalinc', 'linear', 'GS',
+                              'linear, mtrx', 'linear, mtry'])
+def test_txfunc_est(rate_type, tax_func_type, numparams,
+                    expected_tuple):
     '''
     Test txfunc.txfunc_est() function.  The test is that given
     inputs from previous run, the outputs are unchanged.
     '''
     input_tuple = utils.safe_read_pickle(
         os.path.join(CUR_PATH, 'test_io_data', 'txfunc_est_inputs.pkl'))
-    (df, s, t, rate_type, output_dir, graph) = input_tuple
+    (df, s, t, _, output_dir, graph) = input_tuple
     # Put old df variables into new df var names
     df.rename(columns={
         'MTR labor income': 'mtr_labinc',
@@ -183,7 +191,6 @@ def test_txfunc_est(tax_func_type, numparams, expected_tuple):
         'Weights': 'weight'}, inplace=True)
     test_tuple = txfunc.txfunc_est(df, s, t, rate_type, tax_func_type,
                                    numparams, output_dir, True)
-    print('test_tuple = ', test_tuple)
 
     for i, v in enumerate(expected_tuple):
         assert(np.allclose(test_tuple[i], v))

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -175,7 +175,7 @@ def get_tax_rates(params, X, Y, wgts, tax_func_type, rate_type,
                 txrates = tau_income + shift_income + shift
     elif tax_func_type == 'linear':
         rate = np.squeeze(params[..., 0])
-        txrates = rate
+        txrates = rate * np.ones_like(income)
 
     return txrates
 

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -520,9 +520,9 @@ def txfunc_est(df, s, t, rate_type, tax_func_type, numparams,
         params = np.zeros(numparams)
         wsse = 0.0
         obs = df.shape[0]
-        params[10] = (
+        params = (
             (txrates * wgts * income).sum() / (income * wgts).sum())
-        params_to_plot = params[1:11]
+        params_to_plot = params
     else:
         raise RuntimeError("Choice of tax function is not in the set of"
                            + " possible tax functions.  Please select"

--- a/ogusa/txfunc.py
+++ b/ogusa/txfunc.py
@@ -520,7 +520,7 @@ def txfunc_est(df, s, t, rate_type, tax_func_type, numparams,
         params = np.zeros(numparams)
         wsse = 0.0
         obs = df.shape[0]
-        params = (
+        params[0] = (
             (txrates * wgts * income).sum() / (income * wgts).sum())
         params_to_plot = params
     else:


### PR DESCRIPTION
This PR fixes an issue with the indexing of parameters for the linear tax rate functions.  An index was not properly updated when changes were made to the tax rate functions in PR #629.

Tests are also added to cover all cases in the `txfunc.txfunc_est()` function.