### PR TITLE
Fix user input of initial_debt_ratio on C/S

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -156,8 +156,8 @@ def run_model(meta_param_dict, adjustment):
         utils.mkdirs(_dir)
 
     # Dask parmeters
-    client = Client()
-    num_workers = 5
+    client = None#Client()
+    num_workers = 1#5
     # TODO: Swap to these parameters when able to specify tax function
     # and model workers separately
     # num_workers_txf = 5
@@ -173,8 +173,9 @@ def run_model(meta_param_dict, adjustment):
     constant_param_set = {
         'frisch', 'beta_annual', 'sigma', 'g_y_annual', 'gamma',
         'epsilon', 'Z', 'delta_annual', 'small_open', 'world_int_rate',
-        'initial_foreign_debt_ratio', 'zeta_D', 'zeta_K', 'tG1', 'tG2',
-        'rho_G', 'debt_ratio_ss', 'budget_balance'}
+        'initial_debt_ratio', 'initial_foreign_debt_ratio', 'zeta_D',
+        'zeta_K', 'tG1', 'tG2', 'rho_G', 'debt_ratio_ss',
+        'budget_balance'}
     filtered_ogusa_params = OrderedDict()
     for k, v in adjustment['OG-USA Parameters'].items():
         if k in constant_param_set:
@@ -187,7 +188,7 @@ def run_model(meta_param_dict, adjustment):
         OGDIR = os.path.dirname(OGPATH)
         tax_func_path = None#os.path.join(OGDIR, 'data', 'tax_functions',
                         #             cached_pickle)
-        run_micro_baseline = False
+        run_micro_baseline = True
     else:
         tax_func_path = None
         run_micro_baseline = True
@@ -241,7 +242,7 @@ def run_model(meta_param_dict, adjustment):
 
     # Shut down client and make sure all of its references are
     # cleaned up.
-    client.close()
+    # client.close()
     del client
 
     return comp_dict

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -156,8 +156,8 @@ def run_model(meta_param_dict, adjustment):
         utils.mkdirs(_dir)
 
     # Dask parmeters
-    client = None#Client()
-    num_workers = 1#5
+    client = Client()
+    num_workers = 5
     # TODO: Swap to these parameters when able to specify tax function
     # and model workers separately
     # num_workers_txf = 5
@@ -196,6 +196,12 @@ def run_model(meta_param_dict, adjustment):
         **{'start_year': start_year,
            'tax_func_type': 'DEP',
            'age_specific': False}, **filtered_ogusa_params}
+    print('BASE SPEC = ', base_spec)
+    print('FILTERED PARAMS = ', filtered_ogusa_params)
+    print('ADJUSTMENT = ', adjustment['OG-USA Parameters'])
+    reform_spec = base_spec
+    reform_spec.update(adjustment["OG-USA Parameters"])
+    print('REFORM SPEC = ', reform_spec)
     base_params = Specifications(
         run_micro=False, output_base=base_dir, baseline_dir=base_dir,
         test=False, time_path=False, baseline=True, iit_reform={},
@@ -242,7 +248,7 @@ def run_model(meta_param_dict, adjustment):
 
     # Shut down client and make sure all of its references are
     # cleaned up.
-    # client.close()
+    client.close()
     del client
 
     return comp_dict

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -196,12 +196,6 @@ def run_model(meta_param_dict, adjustment):
         **{'start_year': start_year,
            'tax_func_type': 'DEP',
            'age_specific': False}, **filtered_ogusa_params}
-    print('BASE SPEC = ', base_spec)
-    print('FILTERED PARAMS = ', filtered_ogusa_params)
-    print('ADJUSTMENT = ', adjustment['OG-USA Parameters'])
-    reform_spec = base_spec
-    reform_spec.update(adjustment["OG-USA Parameters"])
-    print('REFORM SPEC = ', reform_spec)
     base_params = Specifications(
         run_micro=False, output_base=base_dir, baseline_dir=base_dir,
         test=False, time_path=False, baseline=True, iit_reform={},

--- a/cs-config/write_output.py
+++ b/cs-config/write_output.py
@@ -3,6 +3,8 @@ import cs_storage
 from cs_storage.screenshot import write_template
 from ogusa import utils
 from ogusa.parameters import Specifications
+import pickle
+import io
 
 '''
 This script is useful to testing the outputs from the cs_config/functions.py
@@ -10,36 +12,54 @@ script.  Those outputs will be saved in the
 /cs_config/OUTPUT_BASELINE/ and /cs_config/OUTPUT_REFORM/ folders
 that are read in below.
 '''
+def generate_plots():
+    base_ss = utils.safe_read_pickle(
+        './cs_config/OUTPUT_BASELINE/SS/SS_vars.pkl')
+    base_tpi = utils.safe_read_pickle(
+        './cs_config/OUTPUT_BASELINE/TPI/TPI_vars.pkl')
+    reform_ss = utils.safe_read_pickle(
+        './cs_config/OUTPUT_REFORM/SS/SS_vars.pkl')
+    reform_tpi = utils.safe_read_pickle(
+        './cs_config/OUTPUT_REFORM/TPI/TPI_vars.pkl')
+    time_path = True
+    base_params = Specifications()
+    reform_params = Specifications()
 
-base_ss = utils.safe_read_pickle(
-    './cs_config/OUTPUT_BASELINE/SS/SS_vars.pkl')
-base_tpi = utils.safe_read_pickle(
-    './cs_config/OUTPUT_BASELINE/TPI/TPI_vars.pkl')
-reform_ss = utils.safe_read_pickle(
-    './cs_config/OUTPUT_REFORM/SS/SS_vars.pkl')
-reform_tpi = utils.safe_read_pickle(
-    './cs_config/OUTPUT_REFORM/TPI/TPI_vars.pkl')
-time_path = True
-base_params = Specifications()
-reform_params = Specifications()
+    # outputs = functions.run_model(meta_param_dict, adjustment_dict)
+    outputs = functions.comp_output(
+        base_params, base_ss, reform_params, reform_ss,
+        time_path, base_tpi=base_tpi, reform_tpi=reform_tpi,
+        var='cssmat')
 
-meta_param_dict = {'year': [{'value': 2020}],
-                   'data_source': [{'value': 'CPS'}],
-                   'time_path': [{'value': True}]}
-adjustment_dict = {'OG-USA Parameters': {'frisch': 0.41},
-                   'Tax-Calculator Parameters': {}}
-# outputs = functions.run_model(meta_param_dict, adjustment_dict)
-outputs = functions.comp_output(
-    base_params, base_ss, reform_params, reform_ss,
-    time_path, base_tpi=base_tpi, reform_tpi=reform_tpi,
-    var='cssmat')
+    for output in outputs["renderable"]:
+        serializer = cs_storage.get_serializer(output["media_type"])
+        ser = serializer.serialize(output["data"])
+        deserialized = dict(
+            output, data=serializer.deserialize(ser, json_serializable=True)
+        )
+        res = write_template(deserialized)
+        with open(f"{output['title']}.html", "w") as f:
+            f.write(res)
 
-for output in outputs["renderable"]:
-    serializer = cs_storage.get_serializer(output["media_type"])
-    ser = serializer.serialize(output["data"])
-    deserialized = dict(
-        output, data=serializer.deserialize(ser, json_serializable=True)
-    )
-    res = write_template(deserialized)
-    with open(f"{output['title']}.html", "w") as f:
-        f.write(res)
+
+def run_model():
+    meta_param_dict = {'year': [{'value': 2020}],
+                       'data_source': [{'value': 'CPS'}],
+                       'time_path': [{'value': True}]}
+    adjustment_dict = {'OG-USA Parameters': {
+                                             'frisch': 0.39,
+                                             'initial_debt_ratio': 1.1,
+                                             'g_y_annual': 0.029,
+                                             'tG1': 22},
+                       'Tax-Calculator Parameters': {}}
+    comp_dict = functions.run_model(meta_param_dict, adjustment_dict)
+    pickle.dump(comp_dict, open('ogusa_cs_test_dict.pkl', 'wb'))
+    s = io.StringIO(comp_dict['downloadable'][0]['data'])
+    with open('ogusa_test_output.csv', 'w') as f:
+        for line in s:
+            f.write(line)
+
+
+if __name__ == "__main__":
+    generate_plots()
+    run_model()


### PR DESCRIPTION
This PR updates `functions.py` so that the initial debt to GDP ratio input by the user will be applied to the baseline run of the model. 

NB that this parameter does not affect the reform run, which takes the level of debt from the baseline ([see lines 70-73 of `fiscal.py`](https://github.com/PSLmodels/OG-USA/blob/45b8c2d31f8d88d68a0fad8b281077321c386d97/ogusa/fiscal.py#L70)).