### PR TITLE
Update estimate_beta_j.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ htmlcov/*
 envs/
 *.egg-info/
 dask-worker-space/
+ogusa_calibrate/data/TxFuncEst_baseline_PUF.pkl

--- a/ogusa_calibrate/estimate_beta_j.py
+++ b/ogusa_calibrate/estimate_beta_j.py
@@ -10,6 +10,8 @@ import os
 import scipy.optimize as opt
 import pandas as pd
 import pickle
+import sys
+
 from ogusa.parameters import Specifications
 from ogusa import wealth
 from ogusa import SS
@@ -73,11 +75,9 @@ def beta_estimate(
     # initialize parametes object
     tax_func_path = os.path.join(
         "ogusa_calibrate",
-        "data",  # add ogusa above for last ditch effort
+        "data",
         "TxFuncEst_baseline_PUF.pkl",
     )
-    print(tax_func_path)
-    print(os.path.isfile(tax_func_path))
     p = Specifications(baseline=True, tax_func_path=tax_func_path)
     p.update_specifications(og_spec)
     p.get_tax_function_parameters(client, False, tax_func_path)
@@ -90,11 +90,8 @@ def beta_estimate(
     W = compute_weighting_matrix(p, optimal_weight=False)
 
     # call minimizer
-    # set bounds on beta estimates (need to be between 0 and 1)
-    bnds = np.tile(
-        np.array([0.85, 0.995]), (p.J, 1)
-    )  # Need (1e-12, 1) J times
-    # pack arguments in a tuple
+    # set reasonable bounds on beta estimates [0.85,0.995]
+    bnds = np.tile(np.array([0.85, 0.995]))
     min_args = (data_moments, W, p, client)
     # NOTE: may want to try some global optimization routing like
     # simulated annealing (aka basin hopping) or differential


### PR DESCRIPTION
The function is currently running into error within opt.minise: "ValueError: length of x0 != length of bounds"

This commit includes more detailed documentation; set default values of Beta centred on 0.96 that meet expected monotonicity, function now no longer needs Beta arguments; implemented history path to save outputs and update starting values (thanks Max!);  fixed typos mispecifying direction in 1+/-h optimization process; narrower bounds on minimizer for beta estimates [0.85,0.995]; PEP8.

To do:
1) Implement improved estimation procedure
2) Set the constant SS.ENFORCE_SOLUTION_CHECKS to False.  This will at least prevent your estimation from stopping.  But NaN's will be returned to the criteria function, so that may prevent the root finder from progressing well.  You can do this near the top of the estimate_beta_j.py script (where the VERBOSE flag is also set).
3) Set bounds on the optimizer used to minimize the statistical objective function to limit the range of beta (I've found that keeping beta > 0.90 for the lowest lifetime income group and increasing from there works well with the default interest rate guess).
4) Write some code into the minstat() function to keep if the SS solved and if not to change the initial guess for the SS interest rate. This can be done by updating the initial guess parameter in the Specifcations object. Psuedo code for this: