### PR TITLE
update style file url

### DIFF
--- a/ogusa/calibrate.py
+++ b/ogusa/calibrate.py
@@ -9,8 +9,8 @@ import pkg_resources
 import matplotlib.pyplot as plt
 
 style_file = os.path.join(
-    "https://github.com/PSLmodels/OG-Core/blob/master/ogcore/"
-    + "OGcorePlots.mplstyle"
+    "https://raw.githubusercontent.com/PSLmodels/OG-Core/master/ogcore"
+    + "/OGcorePlots.mplstyle"
 )
 plt.style.use(style_file)
 


### PR DESCRIPTION
This PR updates the URL for the matplotlib style file.  I *think* this will stop the warnings that appeared when trying to look for a style file at the previous URL.  Note that this URL is referenced because, to my knowledge, a style file can't be part of a python package (e.g., OG-Core).

At some point, we may want each country model to have it's own style file (e.g., with country-specific colors).  But this should help in the meantime.