### PR TITLE
Added numpy<=1.21.2 constraint to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python>=3.7.7
 - mkl>=2020.2
-- numpy
+- numpy<=1.21.2
 - psutil
 - scipy>=1.5.0
 - pandas>=1.2.5

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python>=3.7.7
 - mkl>=2020.2
-- numpy<=1.21.2
+- numpy<=1.21.2  # This restriction can be removed as soon as Numba supports NumPy 1.22
 - psutil
 - scipy>=1.5.0
 - pandas>=1.2.5

--- a/ogusa/deterministic_profiles.py
+++ b/ogusa/deterministic_profiles.py
@@ -107,8 +107,8 @@ def estimate_profiles(graphs=False):
             earn_profile = (
                 model_results[group][0]
                 + model_results[group][2] * age_vec
-                + model_results[group][4] * age_vec ** 2
-                + model_results[group][6] * age_vec ** 3
+                + model_results[group][4] * age_vec**2
+                + model_results[group][6] * age_vec**3
             )
             plt.plot(age_vec, earn_profile, label=group)
         plt.title(

--- a/ogusa/income.py
+++ b/ogusa/income.py
@@ -112,9 +112,9 @@ def arc_error(abc_vals, params):
     a, b, c = abc_vals
     first_point, coef1, coef2, coef3, abil_deprec = params
     error1 = first_point - arctan_func(80, a, b, c)
-    if (3 * coef3 * 80 ** 2 + 2 * coef2 * 80 + coef1) < 0:
+    if (3 * coef3 * 80**2 + 2 * coef2 * 80 + coef1) < 0:
         error2 = (
-            3 * coef3 * 80 ** 2 + 2 * coef2 * 80 + coef1
+            3 * coef3 * 80**2 + 2 * coef2 * 80 + coef1
         ) * first_point - arctan_deriv_func(80, a, b, c)
     else:
         error2 = -0.02 * first_point - arctan_deriv_func(80, a, b, c)
@@ -406,8 +406,8 @@ def get_e_orig(age_wgts, abil_wgts, plot=False):
     log_abil_paths = (
         const
         + (one * ages_short)
-        + (two * (ages_short ** 2))
-        + (three * (ages_short ** 3))
+        + (two * (ages_short**2))
+        + (three * (ages_short**3))
     )
     abil_paths = np.exp(log_abil_paths)
     e_orig = np.zeros((80, 7))


### PR DESCRIPTION
The current `taxcalc` package's use of `numba` is not compatible with `numpy 1.22.2`. I tried a clean install tonight of the `ogusa-dev` conda environment using the current [`environment.yml`](https://github.com/PSLmodels/OG-USA/blob/master/environment.yml) file. After activating the new `ogusa-dev` conda environment and running `pip install -e .`, I tried to run the example script [`run_og_usa.py`](https://github.com/PSLmodels/OG-USA/blob/master/examples/run_og_usa.py). This script immediately generated the following traceback error.
```
(ogusa-dev) richardevans@Rick-MacBook-Pro-2020 OG-USA % python ./examples/run_og_usa.py
Traceback (most recent call last):
  File "/Users/richardevans/Documents/Economics/OSE/OG-USA/./examples/run_og_usa.py", line 6, in <module>
    from taxcalc import Calculator
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/taxcalc/__init__.py", line 4, in <module>
    from taxcalc.calculator import *
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/taxcalc/calculator.py", line 14, in <module>
    from taxcalc.calcfunctions import (TaxInc, SchXYZTax, GainsTax, AGIsurtax,
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/taxcalc/calcfunctions.py", line 24, in <module>
    from taxcalc.decorators import iterate_jit, JIT
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/taxcalc/decorators.py", line 13, in <module>
    import numba
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/numba/__init__.py", line 200, in <module>
    _ensure_critical_deps()
  File "/Users/richardevans/opt/anaconda3/envs/ogusa-dev/lib/python3.10/site-packages/numba/__init__.py", line 140, in _ensure_critical_deps
    raise ImportError("Numba needs NumPy 1.21 or less")
ImportError: Numba needs NumPy 1.21 or less
```
It looks like it is a problem with the `numba` package in `taxcalc` and the version of `numpy`. It says "`ImportError: Numba needs NumPy 1.21 or less`".

My temporary fix is to set `numpy<=1.21.2` in `environment.yml`. Running the example script with this change allows the program to run. This is obviously a temporary fix until we figure out why `numba` can't talk to `numpy > 1.21.2`. But until then, I recommend this fix.

cc: @jdebacker