### PR TITLE
Update OG-USA documentation

### DIFF
--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -2,7 +2,7 @@
 # Book settings
 title                    : OG-USA
 author                   : Jason DeBacker and Richard W. Evans
-copyright                : '2021'
+copyright                : '2022'
 logo                     : '..//OG-USA_logo.png'
 
 ####################################################

--- a/docs/book/_config.yml
+++ b/docs/book/_config.yml
@@ -50,6 +50,8 @@ sphinx:
                                'sphinx.ext.viewcode', 'sphinx.ext.napoleon',
                                'alabaster']   # A list of extra extensions to load by Sphinx.
   config                    :   # key-value pairs to directly over-ride the Sphinx configuration
+    bibtex_reference_style: author_year
+    mathjax_path          : https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 ####################################################
 # LaTeX information

--- a/docs/book/content/OGUSA_references.md
+++ b/docs/book/content/OGUSA_references.md
@@ -1,5 +1,5 @@
 # References
 
 ```{bibliography} ../OGUSA_references.bib
-:style: plain
+:style: alpha
 ```

--- a/docs/book/content/api/public_api.rst
+++ b/docs/book/content/api/public_api.rst
@@ -21,3 +21,4 @@ There is also a link to the source code for each documented member.
    macro_params
    psid_data_setup
    transfer_distribution
+   utils

--- a/docs/book/content/api/public_api.rst
+++ b/docs/book/content/api/public_api.rst
@@ -1,6 +1,6 @@
 API
 =========================
-The source code for `OG-USA` is located in the `OG-USA/ogusa` directory tree.
+The source code for `OG-USA` is located in the `/OG-USA/ogusa/` directory tree.
 
 Here we provide a high-level view of the API of the `OG-USA` package, with links
 to the source code. This high-level view is organized around the modules that

--- a/docs/book/content/calibration/tax_functions.md
+++ b/docs/book/content/calibration/tax_functions.md
@@ -290,8 +290,11 @@ The second difficulty in modeling realistic tax and incentive detail is the need
 
   However, this distribution function $\eta_{j,s,t}$ could also be modified to more accurately reflect the way transfers are distributed in the United States.
 
-[^taxcalc_note]:`Tax-Calculator` is available through an open source repository [https://github.com/PSLmodels/Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator) as well as through a web application [Tax-Brain](https://compute.studio/PSLmodels/Tax-Brain/), hosted by [Compute.Studio](https://about.compute.studio/). Documentation for `Tax-Calculator` is available at [https://taxcalc.pslmodels.org/](https://taxcalc.pslmodels.org/).
+(SecTaxfootnotes)=
+## Footnotes
 
-[^interpolation_note]: We use two criterion to determine whether the function should be interpolated. First, we require a minimum number of observations of filers of that age and in that tax year. Second, we require that that sum of squared errors meet a predefined threshold.
+  [^taxcalc_note]:`Tax-Calculator` is available through an open source repository [https://github.com/PSLmodels/Tax-Calculator](https://github.com/PSLmodels/Tax-Calculator) as well as through a web application [Tax-Brain](https://compute.studio/PSLmodels/Tax-Brain/), hosted by [Compute.Studio](https://about.compute.studio/). Documentation for `Tax-Calculator` is available at [https://taxcalc.pslmodels.org/](https://taxcalc.pslmodels.org/).
 
-[^param_note]: We assume that whatever parameters the tax functions have in year 10 persist forever.
+  [^interpolation_note]: We use two criterion to determine whether the function should be interpolated. First, we require a minimum number of observations of filers of that age and in that tax year. Second, we require that that sum of squared errors meet a predefined threshold.
+
+  [^param_note]: We assume that whatever parameters the tax functions have in year 10 persist forever.

--- a/docs/book/content/contributing/contributor_guide.md
+++ b/docs/book/content/contributing/contributor_guide.md
@@ -23,7 +23,7 @@ If you have already completed the {ref}`Sec_SetupPython` and {ref}`Sec_SetupGit`
 
 3. Tell Git to remember your GitHub password by following steps 1-4 on [password setup](https://help.github.com/articles/caching-your-github-password-in-git/).
 
-4. Sign in to GitHub and create your own [remote](https://help.github.com/articles/github-glossary/#remote) [repository](https://help.github.com/articles/github-glossary/#repository) (repo) of `OG-USA` by clicking [Fork](https://help.github.com/articles/github-glossary/#fork) in the upper right corner of the [OG-USA GitHub page](https://github.com/PSLmodels/OG-USA). Select your username when asked "Where should we fork this repository?"
+4. Sign in to GitHub and create your own [remote](https://help.github.com/articles/github-glossary/#remote) [repository](https://help.github.com/articles/github-glossary/#repository) (repo) of `OG-USA` by clicking [Fork](https://help.github.com/articles/github-glossary/#fork) in the upper right corner of the [OG-USA GitHub repository page](https://github.com/PSLmodels/OG-USA). Select your username when asked "Where should we fork this repository?"
 
 5. From your command line, navigate to the directory on your computer where you would like your local repo to live.
 
@@ -43,8 +43,7 @@ If you have already completed the {ref}`Sec_SetupPython` and {ref}`Sec_SetupGit`
     ```
 
 9. Create a conda environment with all of the necessary packages to execute the source code.
-The process of creating the `ogusa-dev` conda environment can take more than 20 minutes.
-The pip install of the `OG-Core` dependency from GitHub takes most of the time.
+The process of creating the `ogusa-dev` conda environment can take up to 10 minutes. The pip install of the `OG-Core` dependency from [pypi.org](https://pypi.org/project/ogcore/).
 
     ```
       OG-USA$ conda env create
@@ -72,7 +71,7 @@ local repo. As a new contributor, you will push your changes from your
 local repo to your remote repo when you're ready to share that work
 with the team.
 
-Don't be alarmed if the above paragraph is confusing. The following
+Don't be alarmed if the above paragraphs are confusing. The following
 section introduces some standard Git practices and guides you through
 the contribution process.
 
@@ -119,18 +118,14 @@ situations, in which case other contributors are here to help.
     ```
         OG-USA$ git push origin master
     ```
-2. Create a new [branch](https://help.github.com/articles/github-glossary/#branch) on your local machine. Think of your
-   branches as a way to organize your projects. If you want to work on
-   this documentation, for example, create a separate branch for that
-   work. If you want to change an element of the OG-USA model, create
-   a different branch for that project:
+2. Create a new [branch](https://help.github.com/articles/github-glossary/#branch) on your local machine. Think of your branches as a way to organize your projects. If you want to work on this documentation, for example, create a separate branch for that work. If you want to change an element of the OG-USA model, create a different branch for that project:
     ```
      OG-USA$ git checkout -b [new-branch-name]
     ```
 3. As you make changes, frequently check that your changes do not
-   introduce bugs or degrade the accuracy of the OG-USA. To do
+   introduce bugs or degrade the accuracy of the `OG-USA`. To do
    this, run the following command from the command line from inside
-   the OG-USA/ogusa directory:
+   the `/OG-USA/ogusa/` directory:
     ```
      OG-USA/ogusa$  pytest -m "not needs_puf and not regression"
     ```

--- a/docs/book/content/intro/intro.md
+++ b/docs/book/content/intro/intro.md
@@ -25,4 +25,4 @@ The model is continuously under development. Users will be notified through [clo
 (Sec_CitingOGUSA)=
 ## Citing OG-USA
 
-`OG-USA` (Version 0.6.3)[Source code], https://github.com/PSLmodels/OG-USA
+`OG-USA` (Version #.#.#)[Source code], https://github.com/PSLmodels/OG-USA


### PR DESCRIPTION
This PR implements the following updates to the documentation.

* Update the copyright year in `_config.yml`
* Differentiate directories from the package with slashes (`public_api.rst`, `contributor_guide.md`)
* Update the BibTeX reference style.
* Basic stylistic and typographical changes.

cc: @jdebacker 