### PR TITLE
Fixed repo path name in deploy_docs.yml

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -5,11 +5,11 @@ on:
       - master
 jobs:
   build-and-deploy:
-    if: github.repository == 'PSLmodels/OG-USA-Calibration'
+    if: github.repository == 'PSLmodels/OG-USA'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        uses: actions/checkout@v2  # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
         with:
           persist-credentials: false
 


### PR DESCRIPTION
This PR fixes the path name for the repository in the `deploy_docs.yml`. I think this was causing any updates in the documentation to not deploy to the GitHub Jupyter Book upon pushes to the master branch.

cc: @jdebacker 