### PR TITLE
Set n_workers for dask LocalCluster

### DIFF
--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -14,8 +14,8 @@ from ogcore.utils import safe_read_pickle
 
 def main():
     # Define parameters to use for multiprocessing
-    client = Client()
     num_workers = min(multiprocessing.cpu_count(), 7)
+    client = Client(n_workers=num_workers)
     print("Number of workers = ", num_workers)
 
     # Directories to save data


### PR DESCRIPTION
 - Explicitly set n_workers for LocalCluster creation (through Client). If this is not set, for machines with a high CPU count, the number of workers will be much larger than 7. In `client.scatter` with `broadcast=True`, this can cause hangs due to how dask distributed works. It's presumed that this bug is only apparent in more recent runs on machines with high CPU counts, although that is not confirmed. But, this fix does allow the example to run to completion on a machine with CPU_COUNT=128.