### PR TITLE
Dealing with Dask memory issues in the run script, #2

### DIFF
--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -47,6 +47,10 @@ def main():
     )
     p.tax_func_type = "GS"
     c = Calibration(p, estimate_tax_functions=True, client=client)
+    # close and delete client bc cache is too large
+    client.close()
+    del client
+    client = Client(n_workers=num_workers)
     d = c.get_dict()
     # # additional parameters to change
     updated_params = {
@@ -100,6 +104,10 @@ def main():
     c2 = Calibration(
         p2, iit_reform=iit_reform, estimate_tax_functions=True, client=client
     )
+    # close and delete client bc cache is too large
+    client.close()
+    del client
+    client = Client(n_workers=num_workers)
     # update tax function parameters in Specifications Object
     d = c2.get_dict()
     # # additional parameters to change


### PR DESCRIPTION
Following up on PR #85, I noticed that despite this changes I was again seeing memory warnings:

```
2024-02-08 09:49:00,004 - distributed.utils_perf - WARNING - full garbage collections took 14% CPU time recently (threshold: 10%)
```

And no, or slow, progress in when running `run_og_usa.py` when running with OG-Core 0.11.0 (which increases the size of several objects in the `Specifications` class object that contains the model parameters.

After some profiling, I noticed that the "bytes stored" in the `dask` processes became quite large with the tax function estimation, but then remained quite high after that task completed:  

![Dask_status_ogusa_taxfunc_big_memory](https://github.com/PSLmodels/OG-USA/assets/10715924/88992d32-51bd-4ec4-aac1-51075e7b4c3e)

This PR helps deal with that issue by closing and deleting the client after tax function estimation and then instantiating a new client before the model solution algorithm is called.

This has seemed to avoid these issues.