### PR TITLE
Updated ryp2 dependency

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -35,6 +35,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -44,10 +48,6 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
-      - name: Set up R ${{ matrix.r-version }}
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: release
       - name: Build
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,6 +44,10 @@ jobs:
           environment-file: environment.yml
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
+      - name: Set up R ${{ matrix.r-version }}
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
       - name: Build
         shell: bash -l {0}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2024-05-14 16:30:00
+
+### Added
+
+- Updates the dependency `rpy2>=3.5.12` in `environment.yml` and `setup.py`.
+
+
 ## [0.1.6] - 2024-05-08 10:30:00
 
 ### Added
@@ -90,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+[0.1.7]: https://github.com/PSLmodels/OG-USA/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/PSLmodels/OG-USA/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/PSLmodels/OG-USA/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/PSLmodels/OG-USA/compare/v0.1.3...v0.1.4

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
 - python>=3.7.7,<3.12
 - numpy
 - setuptools
+- wheel
 - numba>=0.54
 - scipy>=1.7.1
 - pandas>=1.2.5

--- a/environment.yml
+++ b/environment.yml
@@ -26,10 +26,10 @@ dependencies:
 - xlwt
 - statsmodels
 - linearmodels
-- rpy2>=3.5.12
 - black>=24.1.1
 - pip
 - pip:
+  - rpy2>=3.5.12
   - openpyxl>=3.1.2
   - cs-kit
   - cs2tc

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - xlwt
 - statsmodels
 - linearmodels
-- rpy2<=3.5.11
+- rpy2>=3.5.12
 - black>=24.1.1
 - pip
 - pip:

--- a/ogusa/psid_data_setup.py
+++ b/ogusa/psid_data_setup.py
@@ -6,8 +6,12 @@ from pandas_datareader import data as web
 import datetime
 from linearmodels import PanelOLS
 from rpy2.robjects import r
+from rpy2.robjects import conversion
+from rpy2.robjects import default_converter
 from rpy2.robjects import pandas2ri
+from rpy2.robjects.packages import importr
 from ogusa.constants import PSID_NOMINAL_VARS, PSID_CONSTANT_VARS
+
 
 pandas2ri.activate()
 pd.options.mode.chained_assignment = "raise"
@@ -34,7 +38,9 @@ def prep_data(data="psid1968to2015.RData"):
     """
     # Read data from R into pandas dataframe
     r["load"](os.path.join(CURDIR, "..", "data", "PSID", data))
-    raw_df = r("psid_df")
+    raw_r_df = r("psid_df")
+    with (default_converter + pandas2ri.converter).context():
+        raw_df = conversion.get_conversion().rpy2py(raw_r_df)
 
     # Create unique identifier for each household
     # note that will define a new household if head or spouse changes

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as readme_file:
 
 setuptools.setup(
     name="ogusa",
-    version="0.1.6",
+    version="0.1.7",
     author="Jason DeBacker and Richard W. Evans",
     license="CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
     description="USA calibration for OG-Core",
@@ -32,7 +32,7 @@ setuptools.setup(
         "paramtools>=0.15.0",
         "taxcalc>=3.0.0",
         "requests",
-        "rpy2<=3.5.11",
+        "rpy2>=3.5.12",
         "pandas-datareader",
         "xlwt",
         "openpyxl>=3.1.2",


### PR DESCRIPTION
This PR:
- Updates the dependency `rpy2>=3.5.12` in `environment.yml` and `setup.py`. This is meant to fix the error below in installing OG-USA in another repository.
- Moves the `rpy2` package download out of the `conda-forge` channel in the `environment.yml` file into the `pip` download section.
- Updates the rpy2 API commands in `psid_data_setup.py`.
- Adds `wheel` package to `environment.yml` dependencies. It was already in `setup.py`.
- Adds installation of R in `build_and_test.yml`

cc: @jdebacker 