### PR TITLE
Updates to example scripts

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pytest -m "not local" --cov=./ --cov-report=xml
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && contains(github.repository, 'PSLmodels/OG-USA')
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -154,21 +154,31 @@ def main():
 
     # create plots of output
     op.plot_all(
-        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_example_plots_tables")
+        base_dir,
+        reform_dir,
+        os.path.join(CUR_DIR, "OG-USA_example_plots_tables"),
     )
     # Create CSV file with output
     ot.tp_output_dump_table(
-            base_params,
-            base_tpi,
-            reform_params,
-            reform_tpi,
-            table_format="csv",
-            path=os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "macro_time_series_output.csv")
-        )
+        base_params,
+        base_tpi,
+        reform_params,
+        reform_tpi,
+        table_format="csv",
+        path=os.path.join(
+            CUR_DIR,
+            "OG-USA_example_plots_tables",
+            "macro_time_series_output.csv",
+        ),
+    )
 
     print("Percentage changes in aggregates:", ans)
     # save percentage change output to csv file
-    ans.to_csv(os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "ogusa_example_output.csv"))
+    ans.to_csv(
+        os.path.join(
+            CUR_DIR, "OG-USA_example_plots_tables", "ogusa_example_output.csv"
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -37,104 +37,104 @@ def main():
     ------------------------------------------------------------------------
     """
     # Set up baseline parameterization
-    # p = Specifications(
-    #     baseline=True,
-    #     num_workers=num_workers,
-    #     baseline_dir=base_dir,
-    #     output_base=base_dir,
-    # )
-    # # Update parameters for baseline from default json file
-    # p.update_specifications(
-    #     json.load(
-    #         open(
-    #             os.path.join(
-    #                 CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
-    #             )
-    #         )
-    #     )
-    # )
-    # p.tax_func_type = "GS"
-    # p.age_specific = False
-    # c = Calibration(p, estimate_tax_functions=True, client=client)
-    # # close and delete client bc cache is too large
-    # client.close()
-    # del client
-    # client = Client(n_workers=num_workers, threads_per_worker=1)
-    # d = c.get_dict()
-    # # # additional parameters to change
-    # updated_params = {
-    #     "etr_params": d["etr_params"],
-    #     "mtrx_params": d["mtrx_params"],
-    #     "mtry_params": d["mtry_params"],
-    #     "mean_income_data": d["mean_income_data"],
-    #     "frac_tax_payroll": d["frac_tax_payroll"],
-    # }
-    # p.update_specifications(updated_params)
-    # # Run model
-    # start_time = time.time()
-    # runner(p, time_path=True, client=client)
-    # print("run time = ", time.time() - start_time)
+    p = Specifications(
+        baseline=True,
+        num_workers=num_workers,
+        baseline_dir=base_dir,
+        output_base=base_dir,
+    )
+    # Update parameters for baseline from default json file
+    p.update_specifications(
+        json.load(
+            open(
+                os.path.join(
+                    CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
+                )
+            )
+        )
+    )
+    p.tax_func_type = "GS"
+    p.age_specific = False
+    c = Calibration(p, estimate_tax_functions=True, client=client)
+    # close and delete client bc cache is too large
+    client.close()
+    del client
+    client = Client(n_workers=num_workers, threads_per_worker=1)
+    d = c.get_dict()
+    # # additional parameters to change
+    updated_params = {
+        "etr_params": d["etr_params"],
+        "mtrx_params": d["mtrx_params"],
+        "mtry_params": d["mtry_params"],
+        "mean_income_data": d["mean_income_data"],
+        "frac_tax_payroll": d["frac_tax_payroll"],
+    }
+    p.update_specifications(updated_params)
+    # Run model
+    start_time = time.time()
+    runner(p, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
 
-    # """
-    # ------------------------------------------------------------------------
-    # Run reform policy
-    # ------------------------------------------------------------------------
-    # """
-    # # Grab a reform JSON file already in Tax-Calculator
-    # # In this example the 'reform' is a change to 2017 law (the
-    # # baseline policy is tax law in 2018)
-    # reform_url = (
-    #     "github://PSLmodels:examples@main/psl_examples/"
-    #     + "taxcalc/2017_law.json"
-    # )
-    # ref = Calculator.read_json_param_objects(reform_url, None)
-    # iit_reform = ref["policy"]
+    """
+    ------------------------------------------------------------------------
+    Run reform policy
+    ------------------------------------------------------------------------
+    """
+    # Grab a reform JSON file already in Tax-Calculator
+    # In this example the 'reform' is a change to 2017 law (the
+    # baseline policy is tax law in 2018)
+    reform_url = (
+        "github://PSLmodels:examples@main/psl_examples/"
+        + "taxcalc/2017_law.json"
+    )
+    ref = Calculator.read_json_param_objects(reform_url, None)
+    iit_reform = ref["policy"]
 
-    # # create new Specifications object for reform simulation
-    # p2 = Specifications(
-    #     baseline=False,
-    #     num_workers=num_workers,
-    #     baseline_dir=base_dir,
-    #     output_base=reform_dir,
-    # )
-    # # Update parameters for baseline from default json file
-    # p2.update_specifications(
-    #     json.load(
-    #         open(
-    #             os.path.join(
-    #                 CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
-    #             )
-    #         )
-    #     )
-    # )
-    # p2.tax_func_type = "GS"
-    # p2.age_specific = False
-    # # Use calibration class to estimate reform tax functions from
-    # # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
-    # c2 = Calibration(
-    #     p2, iit_reform=iit_reform, estimate_tax_functions=True, client=client
-    # )
-    # # close and delete client bc cache is too large
-    # client.close()
-    # del client
-    # client = Client(n_workers=num_workers, threads_per_worker=1)
-    # # update tax function parameters in Specifications Object
-    # d = c2.get_dict()
-    # # # additional parameters to change
-    # updated_params = {
-    #     "cit_rate": [[0.35]],
-    #     "etr_params": d["etr_params"],
-    #     "mtrx_params": d["mtrx_params"],
-    #     "mtry_params": d["mtry_params"],
-    #     "mean_income_data": d["mean_income_data"],
-    #     "frac_tax_payroll": d["frac_tax_payroll"],
-    # }
-    # p2.update_specifications(updated_params)
-    # # Run model
-    # start_time = time.time()
-    # runner(p2, time_path=True, client=client)
-    # print("run time = ", time.time() - start_time)
-    # client.close()
+    # create new Specifications object for reform simulation
+    p2 = Specifications(
+        baseline=False,
+        num_workers=num_workers,
+        baseline_dir=base_dir,
+        output_base=reform_dir,
+    )
+    # Update parameters for baseline from default json file
+    p2.update_specifications(
+        json.load(
+            open(
+                os.path.join(
+                    CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
+                )
+            )
+        )
+    )
+    p2.tax_func_type = "GS"
+    p2.age_specific = False
+    # Use calibration class to estimate reform tax functions from
+    # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
+    c2 = Calibration(
+        p2, iit_reform=iit_reform, estimate_tax_functions=True, client=client
+    )
+    # close and delete client bc cache is too large
+    client.close()
+    del client
+    client = Client(n_workers=num_workers, threads_per_worker=1)
+    # update tax function parameters in Specifications Object
+    d = c2.get_dict()
+    # # additional parameters to change
+    updated_params = {
+        "cit_rate": [[0.35]],
+        "etr_params": d["etr_params"],
+        "mtrx_params": d["mtrx_params"],
+        "mtry_params": d["mtry_params"],
+        "mean_income_data": d["mean_income_data"],
+        "frac_tax_payroll": d["frac_tax_payroll"],
+    }
+    p2.update_specifications(updated_params)
+    # Run model
+    start_time = time.time()
+    runner(p2, time_path=True, client=client)
+    print("run time = ", time.time() - start_time)
+    client.close()
 
     """
     ------------------------------------------------------------------------

--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -4,12 +4,20 @@ import os
 import json
 import time
 from taxcalc import Calculator
+import matplotlib.pyplot as plt
 from ogusa.calibrate import Calibration
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
 from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
+
+# Use a custom matplotlib style file for plots
+style_file_url = (
+    "https://raw.githubusercontent.com/PSLmodels/OG-Core/"
+    + "master/ogcore/OGcorePlots.mplstyle"
+)
+plt.style.use(style_file_url)
 
 
 def main():
@@ -29,104 +37,104 @@ def main():
     ------------------------------------------------------------------------
     """
     # Set up baseline parameterization
-    p = Specifications(
-        baseline=True,
-        num_workers=num_workers,
-        baseline_dir=base_dir,
-        output_base=base_dir,
-    )
-    # Update parameters for baseline from default json file
-    p.update_specifications(
-        json.load(
-            open(
-                os.path.join(
-                    CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
-                )
-            )
-        )
-    )
-    p.tax_func_type = "GS"
-    p.age_specific = False
-    c = Calibration(p, estimate_tax_functions=True, client=client)
-    # close and delete client bc cache is too large
-    client.close()
-    del client
-    client = Client(n_workers=num_workers, threads_per_worker=1)
-    d = c.get_dict()
-    # # additional parameters to change
-    updated_params = {
-        "etr_params": d["etr_params"],
-        "mtrx_params": d["mtrx_params"],
-        "mtry_params": d["mtry_params"],
-        "mean_income_data": d["mean_income_data"],
-        "frac_tax_payroll": d["frac_tax_payroll"],
-    }
-    p.update_specifications(updated_params)
-    # Run model
-    start_time = time.time()
-    runner(p, time_path=True, client=client)
-    print("run time = ", time.time() - start_time)
+    # p = Specifications(
+    #     baseline=True,
+    #     num_workers=num_workers,
+    #     baseline_dir=base_dir,
+    #     output_base=base_dir,
+    # )
+    # # Update parameters for baseline from default json file
+    # p.update_specifications(
+    #     json.load(
+    #         open(
+    #             os.path.join(
+    #                 CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
+    #             )
+    #         )
+    #     )
+    # )
+    # p.tax_func_type = "GS"
+    # p.age_specific = False
+    # c = Calibration(p, estimate_tax_functions=True, client=client)
+    # # close and delete client bc cache is too large
+    # client.close()
+    # del client
+    # client = Client(n_workers=num_workers, threads_per_worker=1)
+    # d = c.get_dict()
+    # # # additional parameters to change
+    # updated_params = {
+    #     "etr_params": d["etr_params"],
+    #     "mtrx_params": d["mtrx_params"],
+    #     "mtry_params": d["mtry_params"],
+    #     "mean_income_data": d["mean_income_data"],
+    #     "frac_tax_payroll": d["frac_tax_payroll"],
+    # }
+    # p.update_specifications(updated_params)
+    # # Run model
+    # start_time = time.time()
+    # runner(p, time_path=True, client=client)
+    # print("run time = ", time.time() - start_time)
 
-    """
-    ------------------------------------------------------------------------
-    Run reform policy
-    ------------------------------------------------------------------------
-    """
-    # Grab a reform JSON file already in Tax-Calculator
-    # In this example the 'reform' is a change to 2017 law (the
-    # baseline policy is tax law in 2018)
-    reform_url = (
-        "github://PSLmodels:examples@main/psl_examples/"
-        + "taxcalc/2017_law.json"
-    )
-    ref = Calculator.read_json_param_objects(reform_url, None)
-    iit_reform = ref["policy"]
+    # """
+    # ------------------------------------------------------------------------
+    # Run reform policy
+    # ------------------------------------------------------------------------
+    # """
+    # # Grab a reform JSON file already in Tax-Calculator
+    # # In this example the 'reform' is a change to 2017 law (the
+    # # baseline policy is tax law in 2018)
+    # reform_url = (
+    #     "github://PSLmodels:examples@main/psl_examples/"
+    #     + "taxcalc/2017_law.json"
+    # )
+    # ref = Calculator.read_json_param_objects(reform_url, None)
+    # iit_reform = ref["policy"]
 
-    # create new Specifications object for reform simulation
-    p2 = Specifications(
-        baseline=False,
-        num_workers=num_workers,
-        baseline_dir=base_dir,
-        output_base=reform_dir,
-    )
-    # Update parameters for baseline from default json file
-    p2.update_specifications(
-        json.load(
-            open(
-                os.path.join(
-                    CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
-                )
-            )
-        )
-    )
-    p2.tax_func_type = "GS"
-    p2.age_specific = False
-    # Use calibration class to estimate reform tax functions from
-    # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
-    c2 = Calibration(
-        p2, iit_reform=iit_reform, estimate_tax_functions=True, client=client
-    )
-    # close and delete client bc cache is too large
-    client.close()
-    del client
-    client = Client(n_workers=num_workers, threads_per_worker=1)
-    # update tax function parameters in Specifications Object
-    d = c2.get_dict()
-    # # additional parameters to change
-    updated_params = {
-        "cit_rate": [[0.35]],
-        "etr_params": d["etr_params"],
-        "mtrx_params": d["mtrx_params"],
-        "mtry_params": d["mtry_params"],
-        "mean_income_data": d["mean_income_data"],
-        "frac_tax_payroll": d["frac_tax_payroll"],
-    }
-    p2.update_specifications(updated_params)
-    # Run model
-    start_time = time.time()
-    runner(p2, time_path=True, client=client)
-    print("run time = ", time.time() - start_time)
-    client.close()
+    # # create new Specifications object for reform simulation
+    # p2 = Specifications(
+    #     baseline=False,
+    #     num_workers=num_workers,
+    #     baseline_dir=base_dir,
+    #     output_base=reform_dir,
+    # )
+    # # Update parameters for baseline from default json file
+    # p2.update_specifications(
+    #     json.load(
+    #         open(
+    #             os.path.join(
+    #                 CUR_DIR, "..", "ogusa", "ogusa_default_parameters.json"
+    #             )
+    #         )
+    #     )
+    # )
+    # p2.tax_func_type = "GS"
+    # p2.age_specific = False
+    # # Use calibration class to estimate reform tax functions from
+    # # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
+    # c2 = Calibration(
+    #     p2, iit_reform=iit_reform, estimate_tax_functions=True, client=client
+    # )
+    # # close and delete client bc cache is too large
+    # client.close()
+    # del client
+    # client = Client(n_workers=num_workers, threads_per_worker=1)
+    # # update tax function parameters in Specifications Object
+    # d = c2.get_dict()
+    # # # additional parameters to change
+    # updated_params = {
+    #     "cit_rate": [[0.35]],
+    #     "etr_params": d["etr_params"],
+    #     "mtrx_params": d["mtrx_params"],
+    #     "mtry_params": d["mtry_params"],
+    #     "mean_income_data": d["mean_income_data"],
+    #     "frac_tax_payroll": d["frac_tax_payroll"],
+    # }
+    # p2.update_specifications(updated_params)
+    # # Run model
+    # start_time = time.time()
+    # runner(p2, time_path=True, client=client)
+    # print("run time = ", time.time() - start_time)
+    # client.close()
 
     """
     ------------------------------------------------------------------------

--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -46,6 +46,7 @@ def main():
         )
     )
     p.tax_func_type = "GS"
+    p.age_specific = False
     c = Calibration(p, estimate_tax_functions=True, client=client)
     # close and delete client bc cache is too large
     client.close()
@@ -99,6 +100,7 @@ def main():
         )
     )
     p2.tax_func_type = "GS"
+    p2.age_specific = False
     # Use calibration class to estimate reform tax functions from
     # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
     c2 = Calibration(
@@ -152,12 +154,21 @@ def main():
 
     # create plots of output
     op.plot_all(
-        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_example_plots")
+        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_example_plots_tables")
     )
+    # Create CSV file with output
+    ot.tp_output_dump_table(
+            base_params,
+            base_tpi,
+            reform_params,
+            reform_tpi,
+            table_format="csv",
+            path=os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "macro_time_series_output.csv")
+        )
 
     print("Percentage changes in aggregates:", ans)
     # save percentage change output to csv file
-    ans.to_csv("ogusa_example_output.csv")
+    ans.to_csv(os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "ogusa_example_output.csv"))
 
 
 if __name__ == "__main__":

--- a/examples/run_og_usa_current_policy_baseline.py
+++ b/examples/run_og_usa_current_policy_baseline.py
@@ -47,6 +47,7 @@ def main():
         )
     )
     p.tax_func_type = "GS"
+    p.age_specific = False
     # get current policy JSON file
     base_url = (
         "github://PSLmodels:Tax-Calculator@master/taxcalc/"
@@ -111,6 +112,7 @@ def main():
         )
     )
     p2.tax_func_type = "GS"
+    p.age_specific = False
     # Use calibration class to estimate reform tax functions from
     # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
     c2 = Calibration(
@@ -168,12 +170,21 @@ def main():
 
     # create plots of output
     op.plot_all(
-        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_example_plots")
+        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_current_policy_example_plots_tables")
     )
+    # Create CSV file with output
+    ot.tp_output_dump_table(
+            base_params,
+            base_tpi,
+            reform_params,
+            reform_tpi,
+            table_format="csv",
+            path=os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "macro_time_series_output.csv")
+        )
 
     print("Percentage changes in aggregates:", ans)
     # save percentage change output to csv file
-    ans.to_csv("ogusa_example_output.csv")
+    ans.to_csv(os.path.join(CUR_DIR, "OG-USA_current_policy_example_plots_tables", "ogusa_example_output.csv"))
 
 
 if __name__ == "__main__":

--- a/examples/run_og_usa_current_policy_baseline.py
+++ b/examples/run_og_usa_current_policy_baseline.py
@@ -5,12 +5,21 @@ import requests
 import json
 import time
 from taxcalc import Calculator
+import matplotlib.pyplot as plt
 from ogusa.calibrate import Calibration
 from ogcore.parameters import Specifications
 from ogcore import output_tables as ot
 from ogcore import output_plots as op
 from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
+
+
+# Use a custom matplotlib style file for plots
+style_file_url = (
+    "https://raw.githubusercontent.com/PSLmodels/OG-Core/"
+    + "master/ogcore/OGcorePlots.mplstyle"
+)
+plt.style.use(style_file_url)
 
 
 def main():

--- a/examples/run_og_usa_current_policy_baseline.py
+++ b/examples/run_og_usa_current_policy_baseline.py
@@ -170,21 +170,33 @@ def main():
 
     # create plots of output
     op.plot_all(
-        base_dir, reform_dir, os.path.join(CUR_DIR, "OG-USA_current_policy_example_plots_tables")
+        base_dir,
+        reform_dir,
+        os.path.join(CUR_DIR, "OG-USA_current_policy_example_plots_tables"),
     )
     # Create CSV file with output
     ot.tp_output_dump_table(
-            base_params,
-            base_tpi,
-            reform_params,
-            reform_tpi,
-            table_format="csv",
-            path=os.path.join(CUR_DIR, "OG-USA_example_plots_tables", "macro_time_series_output.csv")
-        )
+        base_params,
+        base_tpi,
+        reform_params,
+        reform_tpi,
+        table_format="csv",
+        path=os.path.join(
+            CUR_DIR,
+            "OG-USA_example_plots_tables",
+            "macro_time_series_output.csv",
+        ),
+    )
 
     print("Percentage changes in aggregates:", ans)
     # save percentage change output to csv file
-    ans.to_csv(os.path.join(CUR_DIR, "OG-USA_current_policy_example_plots_tables", "ogusa_example_output.csv"))
+    ans.to_csv(
+        os.path.join(
+            CUR_DIR,
+            "OG-USA_current_policy_example_plots_tables",
+            "ogusa_example_output.csv",
+        )
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes the following updates to the example run scripts:

1. Saves all plot and table output a single folder
2. Saves a table with the full time series of several macro aggregates
3. Uses non-age specific tax functions (important given the high variation across age in functions estimated on recent versions of TaxData/Tax-Calculator (see Issue #96)

