### PR TITLE
Fix bug in `run_og_usa.py`

### DIFF
--- a/examples/run_og_usa.py
+++ b/examples/run_og_usa.py
@@ -87,6 +87,8 @@ def main():
 
     # create new Specifications object for reform simulation
     p2 = copy.deepcopy(p)
+    p2.baseline = False
+    p2.output_base = reform_dir
     # Use calibration class to estimate reform tax functions from
     # Tax-Calculator, specifying reform for Tax-Calculator in iit_reform
     c2 = Calibration(


### PR DESCRIPTION
This PR fixes a bug in the example script, `run_og_usa.py` that was introduced in PR #122.  The error was not updating the `baseline` and `output_base` parameters for the reform run, which mean that the reform run was saved over the baseline run.