### PR TITLE
Updated miniconda version in GH Actions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Miniconda using Python ${{ matrix.python-version }}
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           auto-update-conda: true
           activate-environment: ogusa-dev
           environment-file: environment.yml

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           activate-environment: ogusa-dev
           environment-file: environment.yml
           python-version: "3.11"

--- a/.github/workflows/docs_check.yml
+++ b/.github/workflows/docs_check.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
+          miniconda-version: "latest"
           activate-environment: ogusa-dev
           environment-file: environment.yml
           python-version: "3.11"


### PR DESCRIPTION
This PR updates the miniconda installer version to miniconda instead of mambaforge in our GitHub Actions. See Issue #124. Mambaforge is being deprecated and will begin to cause more and more onerous problems and delays in our GH Actions until January 2025 when it will completely stop working (see this blog post "[Sunsetting Mambaforge](https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/)").

The change is one line in three GH Actions, as recommended in the [setup-miniconda README.md](https://github.com/conda-incubator/setup-miniconda).

cc: @jdebacker 