### PR TITLE
Update Python requirement in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: ogusa-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.10,<3.13
+- python>=3.11,<3.13
 - numpy
 - setuptools
 - wheel


### PR DESCRIPTION
This PR updates the Python requirement in `environment.yml` to `python>=3.11,<3.13`. This solves the problem in Issue #137. I ran this with the change and the environment installed great, and the run script ran well. @jdebacker.